### PR TITLE
Feature/#95 node version upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 defaults: &defaults
   working_directory: /home/circleci/project
   docker:
-    - image: circleci/node:6.10.3
+    - image: circleci/node:8.9.4
 
 jobs:
   setup:
@@ -24,10 +24,10 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: 
+      - run:
           name: Create dir for test results
           command: mkdir -p ./test/results
-      - run: 
+      - run:
           name: Execute unit tests
           command: npm -s run test:xunit > ./test/results/tape.xml
       - store_artifacts:
@@ -41,7 +41,7 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: 
+      - run:
           name: Execute code coverage check
           command: npm -s run test:coverage-check
       - store_artifacts:
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Update NPM registry auth token
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-      - run: 
+      - run:
           name: Publish NPM artifact
           command: npm publish --access public
 
@@ -70,7 +70,7 @@ workflows:
           context: org-global
           filters:
               branches:
-                ignore: 
+                ignore:
                   - /feature*/
                   - /bugfix*/
       - test-unit:
@@ -79,16 +79,16 @@ workflows:
             - setup
           filters:
             branches:
-              ignore: 
+              ignore:
                 - /feature*/
-                - /bugfix*/             
+                - /bugfix*/
       - test-coverage:
           context: org-global
           requires:
             - setup
           filters:
             branches:
-              ignore: 
+              ignore:
                 - /feature*/
                 - /bugfix*/
       - deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,11 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# --------------- #
+# IntelliJ #
+# --------------- #
+.idea/
+
+#package-lock.json
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared code for central services",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
   },
   "homepage": "https://github.com/mojaloop/central-services-shared#readme",
   "dependencies": {
-    "winston": "^2.3.0"
+    "winston": "^2.4.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",
-    "istanbul": "^0.4.5",
-    "sinon": "^1.17.6",
-    "standard": "^8.5.0",
-    "tap-xunit": "^1.4.0",
-    "tape": "^4.6.2",
-    "tapes": "^4.1.0"
+    "istanbul": "0.4.5",
+    "sinon": "4.2.2",
+    "standard": "10.0.3",
+    "tap-xunit": "2.2.0",
+    "tape": "4.8.0",
+    "tapes": "4.1.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/src/encoding.js
+++ b/src/encoding.js
@@ -1,9 +1,9 @@
 'use strict'
 
 exports.toBase64 = (value) => {
-  return new Buffer(value).toString('base64')
+  return Buffer.from(value).toString('base64')
 }
 
 exports.fromBase64 = (value) => {
-  return new Buffer(value, 'base64').toString()
+  return Buffer.from(value, 'base64').toString('utf8')
 }


### PR DESCRIPTION
upgraded all dependencies that could be updated. 

new Buffer() has been deprecated now Buffer.from() will be used

Added to .gitignore idea files and package-lock.json