### PR TITLE
Bugfix/#883 undo removal of fspiop header from switch originated requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "Shared code for central services",
   "main": "src/index.js",
   "scripts": {

--- a/src/util/headers/transformer.js
+++ b/src/util/headers/transformer.js
@@ -123,8 +123,6 @@ const transformHeaders = (headers, config) => {
     // Check to see if we find a regex match the source header containing the switch name.
     // If so we remove the signature added by default.
     delete normalizedHeaders[normalizedKeys[ENUM.Headers.FSPIOP.SIGNATURE]]
-    // Also remove FSPIOP-URI and make FSPIOP-HTTP-Method ALL-CAPS #737
-    delete normalizedHeaders[normalizedKeys[ENUM.Headers.FSPIOP.URI]]
   }
 
   // Per the FSPIOP API spec, remove the Accept header on all PUT requests


### PR DESCRIPTION
- Remove the line of code that strips off `FSPIOP-URI` header from requests originating from Switch.