### PR TITLE
Remove the default "Accept" headers that the `axios` module injects.

### DIFF
--- a/src/util/request.js
+++ b/src/util/request.js
@@ -32,6 +32,10 @@ const ErrorHandler = require('@mojaloop/central-services-error-handling')
 
 const MISSING_FUNCTION_PARAMETERS = 'Missing parameters for function'
 
+// Delete the default headers that the `axios` module inserts as they can brake our conventions.
+// By default it would insert `"Accept":"application/json, text/plain, */*"`.
+delete request.defaults.headers.common.Accept;
+
 /**
  * @function validateParticipant
  *


### PR DESCRIPTION
Remove the default headers that the `axios` module inserts as they can brake our conventions.
By default it would insert `"Accept":"application/json, text/plain, */*"`.