### PR TITLE
Bugfix/#1072 sendrequest adds multiple entries to the error extensionlist

### DIFF
--- a/.ncurc.json
+++ b/.ncurc.json
@@ -1,4 +1,5 @@
 {
   "reject": [
+    "@mojaloop/event-sdk"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -493,9 +493,9 @@
       }
     },
     "@mojaloop/central-services-logger": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-logger/-/central-services-logger-8.5.2.tgz",
-      "integrity": "sha512-9nnpk82Q3UKeY5Tq4xuTuZAwGNNf6PR5NArJiSwx2LA4Kp43Det+6/E01nhqEcA4e5GkdAnraxwk8jOFBQoTkQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/central-services-logger/-/central-services-logger-8.6.0.tgz",
+      "integrity": "sha512-TPr6gnYxJfeUjOccDVM10uibPCF4magYhUUbK8xGuPHUfZNAN1uxKGVdkWoDvHvu5ZCZPolie+12ANogAQIH9Q==",
       "requires": {
         "parse-strings-in-object": "1.2.0",
         "rc": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "8.6.2",
+  "version": "8.6.3",
   "description": "Shared code for central services",
   "main": "src/index.js",
   "scripts": {
@@ -45,7 +45,7 @@
     "@hapi/catbox": "10.2.3",
     "@hapi/catbox-memory": "4.1.1",
     "@mojaloop/central-services-error-handling": "8.6.2",
-    "@mojaloop/central-services-logger": "8.5.2",
+    "@mojaloop/central-services-logger": "8.6.0",
     "@mojaloop/event-sdk": "8.3.0",
     "axios": "0.19.0",
     "base64url": "3.0.1",

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -85,13 +85,14 @@ const sendRequest = async (url, headers, source, destination, method = enums.Htt
       { key: 'sourceFsp', value: source },
       { key: 'destinationFsp', value: destination },
       { key: 'method', value: method },
-      { key: 'request', value: JSON.stringify(requestOptions) }
+      { key: 'request', value: JSON.stringify(requestOptions) },
+      { key: 'errorMessage', value: error.message }
     ]
     if (error.response) {
       extensionArray.push({ key: 'status', value: error.response && error.response.status })
       extensionArray.push({ key: 'response', value: error.response && error.response.data })
     }
-    const cause = JSON.stringify(extensionArray) + error.message
+    const cause = JSON.stringify(extensionArray)
     throw ErrorHandler.Factory.createFSPIOPError(ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR, 'Failed to send HTTP request to host', error, source, [{ key: 'cause', value: cause }])
   }
 }

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -91,7 +91,7 @@ const sendRequest = async (url, headers, source, destination, method = enums.Htt
       extensionArray.push({ key: 'status', value: error.response && error.response.status })
       extensionArray.push({ key: 'response', value: error.response && error.response.data })
     }
-    const cause = JSON.stringify(extensionArray)
+    const cause = JSON.stringify(extensionArray) + error.message
     throw ErrorHandler.Factory.createFSPIOPError(ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR, 'Failed to send HTTP request to host', error, source, [{ key: 'cause', value: cause }])
   }
 }

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -85,8 +85,7 @@ const sendRequest = async (url, headers, source, destination, method = enums.Htt
       { key: 'sourceFsp', value: source },
       { key: 'destinationFsp', value: destination },
       { key: 'method', value: method },
-      { key: 'request', value: JSON.stringify(requestOptions) },
-      { key: 'cause', value: error.message }
+      { key: 'request', value: JSON.stringify(requestOptions) }
     ]
     if (error.response) {
       extensionArray.push({ key: 'status', value: error.response && error.response.status })

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -80,7 +80,7 @@ const sendRequest = async (url, headers, source, destination, method = enums.Htt
     return response
   } catch (error) {
     Logger.error(error)
-    const extenstionArray = [
+    const extensionArray = [
       { key: 'url', value: url },
       { key: 'sourceFsp', value: source },
       { key: 'destinationFsp', value: destination },
@@ -88,10 +88,11 @@ const sendRequest = async (url, headers, source, destination, method = enums.Htt
       { key: 'request', value: JSON.stringify(requestOptions) }
     ]
     if (error.response) {
-      extenstionArray.push({ key: 'status', value: error.response && error.response.status })
-      extenstionArray.push({ key: 'response', value: error.response && error.response.data })
+      extensionArray.push({ key: 'status', value: error.response && error.response.status })
+      extensionArray.push({ key: 'response', value: error.response && error.response.data })
     }
-    throw ErrorHandler.Factory.createFSPIOPError(ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR, 'Failed to send HTTP request to host', error, source, extenstionArray)
+    const cause = JSON.stringify(extensionArray)
+    throw ErrorHandler.Factory.createFSPIOPError(ErrorHandler.Enums.FSPIOPErrorCodes.DESTINATION_COMMUNICATION_ERROR, 'Failed to send HTTP request to host', error, source, [{ key: 'cause', value: cause }])
   }
 }
 


### PR DESCRIPTION
- Stringify extensionArray entries and add as a single 'cause' entry in extensionList instead.
- Locked version for event-sdk due to test failue
- Bumped version