### PR TITLE
Fix/1101 event sdk update

### DIFF
--- a/.ncurc.json
+++ b/.ncurc.json
@@ -1,5 +1,4 @@
 {
   "reject": [
-    "@mojaloop/event-sdk"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,9 +111,9 @@
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.2.tgz",
-      "integrity": "sha512-eBKD/FPxQoY1x6QONW2nBd54QUEyzcFP9FenujmoeDPy1rutVSHki1s/wR68F6O1QfCNDx+ayBH1O2CVNMzyyw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
+      "integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -541,16 +541,16 @@
       }
     },
     "@mojaloop/event-sdk": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/event-sdk/-/event-sdk-8.3.0.tgz",
-      "integrity": "sha512-Shc2NMZPHu8BKU9qPNxJVUhocr+l500DYZ2v+gxDjUL9PgmBCcFKsmGyf10PtV5xK9bLWxviWrhvXdZZyOQ6oQ==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@mojaloop/event-sdk/-/event-sdk-8.6.1.tgz",
+      "integrity": "sha512-vzxOQ5JzBgXHE9HU3we4Lad1a9DxJN/qpp5IwHPwxFZy3hEDzyOy32ib4RKh4CEu5umFIg9FL1qWjGkBgdnxFw==",
       "requires": {
-        "@grpc/proto-loader": "0.5.2",
-        "@mojaloop/central-services-logger": "8.1.2",
+        "@grpc/proto-loader": "0.5.3",
+        "@mojaloop/central-services-logger": "8.6.0",
         "@types/protobufjs": "6.0.0",
         "brototype": "0.0.6",
         "error-callsites": "2.0.2",
-        "grpc": "1.24.0",
+        "grpc": "1.24.2",
         "lodash": "4.17.15",
         "moment": "2.24.0",
         "parse-strings-in-object": "1.2.0",
@@ -559,17 +559,8 @@
         "serialize-error": "4.1.0",
         "sinon": "7.5.0",
         "traceparent": "1.0.0",
+        "tslib": "1.10.0",
         "uuid4": "1.1.4"
-      },
-      "dependencies": {
-        "@mojaloop/central-services-logger": {
-          "version": "8.1.2",
-          "resolved": "https://registry.npmjs.org/@mojaloop/central-services-logger/-/central-services-logger-8.1.2.tgz",
-          "integrity": "sha512-wNnr07xcJNAy+KX2C8Djb6ubeH2c1KkfXMyMJz+/dKrfqyVcqcI0RuhneERZrJMI5Ah4X9Sjcuz+LqH9HQoW/w==",
-          "requires": {
-            "winston": "3.2.1"
-          }
-        }
       }
     },
     "@mojaloop/sdk-standard-components": {
@@ -684,6 +675,15 @@
       "dev": true,
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@types/bytebuffer": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
       }
     },
     "@types/long": {
@@ -3133,14 +3133,15 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.0.tgz",
-      "integrity": "sha512-zq1rUh2uzfMqSfQ3bZvlQuX5yKfd/2vob+l9sK5Qma6P33m7UvyMCVW70+Wz0WTzy9W2A94eQD5XIOxKnZhsYQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+      "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
       "requires": {
+        "@types/bytebuffer": "^5.0.40",
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
         "nan": "^2.13.2",
-        "node-pre-gyp": "^0.13.0",
+        "node-pre-gyp": "^0.14.0",
         "protobufjs": "^5.0.3"
       },
       "dependencies": {
@@ -3177,7 +3178,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true
         },
         "code-point-at": {
@@ -3216,10 +3217,10 @@
           "bundled": true
         },
         "fs-minipass": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -3264,7 +3265,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -3309,7 +3310,7 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -3317,10 +3318,10 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -3350,7 +3351,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.13.0",
+          "version": "0.14.0",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -3362,7 +3363,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -3378,7 +3379,7 @@
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.4.4",
+          "version": "1.4.6",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -3527,12 +3528,12 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.10",
+          "version": "4.4.13",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.5",
+            "minipass": "^2.8.6",
             "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
@@ -3555,7 +3556,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true
         }
       }
@@ -7462,8 +7463,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1292,9 +1292,9 @@
       }
     },
     "chance": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.3.tgz",
-      "integrity": "sha512-XeJsdoVAzDb1WRPRuMBesRSiWpW1uNTo5Fd7mYxPJsAfgX71+jfuCOHOdbyBz2uAUZ8TwKcXgWk3DMedFfJkbg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.4.tgz",
+      "integrity": "sha512-pXPDSu3knKlb6H7ahQfpq//J9mSOxYK8SMtp8MV/nRJh8aLRDIl0ipLH8At8+nVogVwtvPZzyIzY/EbcY/cLuQ==",
       "dev": true
     },
     "chardet": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "description": "Shared code for central services",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@modusbox/mojaloop-sdk-standard-components": "0.0.39",
     "@hapi/hapi": "18.4.0",
     "@hapi/joi": "16.1.8",
-    "chance": "1.1.3",
+    "chance": "1.1.4",
     "faucet": "0.0.1",
     "npm-audit-resolver": "2.1.0",
     "npm-check-updates": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@hapi/catbox-memory": "4.1.1",
     "@mojaloop/central-services-error-handling": "8.6.2",
     "@mojaloop/central-services-logger": "8.6.0",
-    "@mojaloop/event-sdk": "8.3.0",
+    "@mojaloop/event-sdk": "8.6.1",
     "axios": "0.19.0",
     "base64url": "3.0.1",
     "clone": "2.1.2",

--- a/test/unit/util/hapi/plugins/eventPlugin.test.js
+++ b/test/unit/util/hapi/plugins/eventPlugin.test.js
@@ -51,37 +51,37 @@ Test('Event plugin test', async (pluginTest) => {
     test.end()
   })
 
-  // await pluginTest.test('create and finish a span for a route with the sampled tag', async assert => {
-  //   try {
-  //     let span
-  //     server.route({
-  //       method: 'POST',
-  //       path: '/',
-  //       handler: (request, h) => {
-  //         span = request.span
-  //         return 'testing'
-  //       },
-  //       options: {
-  //         id: 'test_route',
-  //         tags: ['sampled']
-  //       }
-  //     })
+  await pluginTest.test('create and finish a span for a route with the sampled tag', async assert => {
+    try {
+      let span
+      server.route({
+        method: 'POST',
+        path: '/',
+        handler: (request, h) => {
+          span = request.span
+          return 'testing'
+        },
+        options: {
+          id: 'test_route',
+          tags: ['sampled']
+        }
+      })
 
-  //     const response = await server.inject({
-  //       method: 'POST',
-  //       url: '/'
-  //     })
+      const response = await server.inject({
+        method: 'POST',
+        url: '/'
+      })
 
-  //     assert.equal(response.statusCode, 200, 'status code is correct')
-  //     assert.ok(span)
-  //     assert.ok(span.isFinished)
-  //     assert.equal(span.spanContext.service, 'test_route')
-  //     assert.end()
-  //   } catch (e) {
-  //     assert.fail()
-  //     assert.end()
-  //   }
-  // })
+      assert.equal(response.statusCode, 200, 'status code is correct')
+      assert.ok(span)
+      assert.ok(span.isFinished)
+      assert.equal(span.spanContext.service, 'test_route')
+      assert.end()
+    } catch (e) {
+      assert.fail()
+      assert.end()
+    }
+  })
 
   await pluginTest.test('create and finish a child span with http context headers', async assert => {
     try {
@@ -113,9 +113,7 @@ Test('Event plugin test', async (pluginTest) => {
       assert.ok(span.isFinished)
       assert.equal(span.spanContext.service, 'test_route')
       assert.equal(span.spanContext.traceId, '9732ca939fbd9f755b5bc07c227c4cd5')
-
       assert.equal(span.spanContext.parentSpanId, 'acd6fbed1e66219c')
-
 
       assert.end()
     } catch (e) {
@@ -124,98 +122,98 @@ Test('Event plugin test', async (pluginTest) => {
     }
   })
 
-  // await pluginTest.test('do not create a span for a route without the sampled tag', async assert => {
-  //   try {
-  //     let span
-  //     server.route({
-  //       method: 'POST',
-  //       path: '/',
-  //       handler: (request, h) => {
-  //         span = request.span
-  //         return 'testing'
-  //       },
-  //       options: {
-  //         id: 'test_route'
-  //       }
-  //     })
+  await pluginTest.test('do not create a span for a route without the sampled tag', async assert => {
+    try {
+      let span
+      server.route({
+        method: 'POST',
+        path: '/',
+        handler: (request, h) => {
+          span = request.span
+          return 'testing'
+        },
+        options: {
+          id: 'test_route'
+        }
+      })
 
-  //     const response = await server.inject({
-  //       method: 'POST',
-  //       url: '/'
-  //     })
+      const response = await server.inject({
+        method: 'POST',
+        url: '/'
+      })
 
-  //     assert.equal(response.statusCode, 200, 'status code is correct')
-  //     assert.notOk(span)
-  //     assert.end()
-  //   } catch (e) {
-  //     assert.fail()
-  //     assert.end()
-  //   }
-  // })
+      assert.equal(response.statusCode, 200, 'status code is correct')
+      assert.notOk(span)
+      assert.end()
+    } catch (e) {
+      assert.fail()
+      assert.end()
+    }
+  })
 
-  // await pluginTest.test('log an error if the response is an error', async assert => {
-  //   try {
-  //     let span
-  //     server.route({
-  //       method: 'POST',
-  //       path: '/',
-  //       handler: (request, h) => {
-  //         span = request.span
-  //         throw Error('testing')
-  //       },
-  //       options: {
-  //         id: 'test_route',
-  //         tags: ['sampled']
-  //       }
-  //     })
+  await pluginTest.test('log an error if the response is an error', async assert => {
+    try {
+      let span
+      server.route({
+        method: 'POST',
+        path: '/',
+        handler: (request, h) => {
+          span = request.span
+          throw Error('testing')
+        },
+        options: {
+          id: 'test_route',
+          tags: ['sampled']
+        }
+      })
 
-  //     const response = await server.inject({
-  //       method: 'POST',
-  //       url: '/'
-  //     })
+      const response = await server.inject({
+        method: 'POST',
+        url: '/'
+      })
 
-  //     assert.equal(response.statusCode, 500, 'status code is correct')
-  //     assert.ok(span)
-  //     assert.ok(span.isFinished)
-  //     assert.equal(span.spanContext.service, 'test_route')
-  //     assert.end()
-  //   } catch (e) {
-  //     assert.fail()
-  //     assert.end()
-  //   }
-  // })
+      assert.equal(response.statusCode, 500, 'status code is correct')
+      assert.ok(span)
+      assert.ok(span.isFinished)
+      assert.equal(span.spanContext.service, 'test_route')
+      assert.end()
+    } catch (e) {
+      assert.fail()
+      assert.end()
+    }
+  })
 
-  // await pluginTest.test('handle an fspiop error', async assert => {
-  //   try {
-  //     let span
-  //     server.route({
-  //       method: 'POST',
-  //       path: '/',
-  //       handler: (request, h) => {
-  //         span = request.span
-  //         throw Error('testing')
-  //       },
-  //       options: {
-  //         id: 'test_route',
-  //         tags: ['sampled']
-  //       }
-  //     })
+  await pluginTest.test('handle an fspiop error', async assert => {
+    try {
+      let span
+      server.route({
+        method: 'POST',
+        path: '/',
+        handler: (request, h) => {
+          span = request.span
+          throw Error('testing')
+        },
+        options: {
+          id: 'test_route',
+          tags: ['sampled']
+        }
+      })
 
-  //     const response = await server.inject({
-  //       method: 'POST',
-  //       url: '/'
-  //     })
+      const response = await server.inject({
+        method: 'POST',
+        url: '/'
+      })
 
-  //     assert.equal(response.statusCode, 500, 'status code is correct')
-  //     assert.ok(span)
-  //     assert.ok(span.isFinished)
-  //     assert.equal(span.spanContext.service, 'test_route')
-  //     assert.end()
-  //   } catch (e) {
-  //     assert.fail()
-  //     assert.end()
-  //   }
-  // })
+      assert.equal(response.statusCode, 500, 'status code is correct')
+      assert.ok(span)
+      assert.ok(span.isFinished)
+      assert.equal(span.spanContext.service, 'test_route')
+      assert.end()
+    } catch (e) {
+      assert.fail()
+      assert.end()
+    }
+  })
 
   await pluginTest.end()
 })

--- a/test/unit/util/hapi/plugins/eventPlugin.test.js
+++ b/test/unit/util/hapi/plugins/eventPlugin.test.js
@@ -51,37 +51,37 @@ Test('Event plugin test', async (pluginTest) => {
     test.end()
   })
 
-  await pluginTest.test('create and finish a span for a route with the sampled tag', async assert => {
-    try {
-      let span
-      server.route({
-        method: 'POST',
-        path: '/',
-        handler: (request, h) => {
-          span = request.span
-          return 'testing'
-        },
-        options: {
-          id: 'test_route',
-          tags: ['sampled']
-        }
-      })
+  // await pluginTest.test('create and finish a span for a route with the sampled tag', async assert => {
+  //   try {
+  //     let span
+  //     server.route({
+  //       method: 'POST',
+  //       path: '/',
+  //       handler: (request, h) => {
+  //         span = request.span
+  //         return 'testing'
+  //       },
+  //       options: {
+  //         id: 'test_route',
+  //         tags: ['sampled']
+  //       }
+  //     })
 
-      const response = await server.inject({
-        method: 'POST',
-        url: '/'
-      })
+  //     const response = await server.inject({
+  //       method: 'POST',
+  //       url: '/'
+  //     })
 
-      assert.equal(response.statusCode, 200, 'status code is correct')
-      assert.ok(span)
-      assert.ok(span.isFinished)
-      assert.equal(span.spanContext.service, 'test_route')
-      assert.end()
-    } catch (e) {
-      assert.fail()
-      assert.end()
-    }
-  })
+  //     assert.equal(response.statusCode, 200, 'status code is correct')
+  //     assert.ok(span)
+  //     assert.ok(span.isFinished)
+  //     assert.equal(span.spanContext.service, 'test_route')
+  //     assert.end()
+  //   } catch (e) {
+  //     assert.fail()
+  //     assert.end()
+  //   }
+  // })
 
   await pluginTest.test('create and finish a child span with http context headers', async assert => {
     try {
@@ -103,6 +103,7 @@ Test('Event plugin test', async (pluginTest) => {
         method: 'POST',
         url: '/',
         headers: {
+          tracestate: 'acmevendor=12312312', 
           traceparent: '00-9732ca939fbd9f755b5bc07c227c4cd5-acd6fbed1e66219c-00'
         }
       })
@@ -112,7 +113,10 @@ Test('Event plugin test', async (pluginTest) => {
       assert.ok(span.isFinished)
       assert.equal(span.spanContext.service, 'test_route')
       assert.equal(span.spanContext.traceId, '9732ca939fbd9f755b5bc07c227c4cd5')
+
       assert.equal(span.spanContext.parentSpanId, 'acd6fbed1e66219c')
+
+
       assert.end()
     } catch (e) {
       assert.fail()
@@ -120,98 +124,98 @@ Test('Event plugin test', async (pluginTest) => {
     }
   })
 
-  await pluginTest.test('do not create a span for a route without the sampled tag', async assert => {
-    try {
-      let span
-      server.route({
-        method: 'POST',
-        path: '/',
-        handler: (request, h) => {
-          span = request.span
-          return 'testing'
-        },
-        options: {
-          id: 'test_route'
-        }
-      })
+  // await pluginTest.test('do not create a span for a route without the sampled tag', async assert => {
+  //   try {
+  //     let span
+  //     server.route({
+  //       method: 'POST',
+  //       path: '/',
+  //       handler: (request, h) => {
+  //         span = request.span
+  //         return 'testing'
+  //       },
+  //       options: {
+  //         id: 'test_route'
+  //       }
+  //     })
 
-      const response = await server.inject({
-        method: 'POST',
-        url: '/'
-      })
+  //     const response = await server.inject({
+  //       method: 'POST',
+  //       url: '/'
+  //     })
 
-      assert.equal(response.statusCode, 200, 'status code is correct')
-      assert.notOk(span)
-      assert.end()
-    } catch (e) {
-      assert.fail()
-      assert.end()
-    }
-  })
+  //     assert.equal(response.statusCode, 200, 'status code is correct')
+  //     assert.notOk(span)
+  //     assert.end()
+  //   } catch (e) {
+  //     assert.fail()
+  //     assert.end()
+  //   }
+  // })
 
-  await pluginTest.test('log an error if the response is an error', async assert => {
-    try {
-      let span
-      server.route({
-        method: 'POST',
-        path: '/',
-        handler: (request, h) => {
-          span = request.span
-          throw Error('testing')
-        },
-        options: {
-          id: 'test_route',
-          tags: ['sampled']
-        }
-      })
+  // await pluginTest.test('log an error if the response is an error', async assert => {
+  //   try {
+  //     let span
+  //     server.route({
+  //       method: 'POST',
+  //       path: '/',
+  //       handler: (request, h) => {
+  //         span = request.span
+  //         throw Error('testing')
+  //       },
+  //       options: {
+  //         id: 'test_route',
+  //         tags: ['sampled']
+  //       }
+  //     })
 
-      const response = await server.inject({
-        method: 'POST',
-        url: '/'
-      })
+  //     const response = await server.inject({
+  //       method: 'POST',
+  //       url: '/'
+  //     })
 
-      assert.equal(response.statusCode, 500, 'status code is correct')
-      assert.ok(span)
-      assert.ok(span.isFinished)
-      assert.equal(span.spanContext.service, 'test_route')
-      assert.end()
-    } catch (e) {
-      assert.fail()
-      assert.end()
-    }
-  })
+  //     assert.equal(response.statusCode, 500, 'status code is correct')
+  //     assert.ok(span)
+  //     assert.ok(span.isFinished)
+  //     assert.equal(span.spanContext.service, 'test_route')
+  //     assert.end()
+  //   } catch (e) {
+  //     assert.fail()
+  //     assert.end()
+  //   }
+  // })
 
-  await pluginTest.test('handle an fspiop error', async assert => {
-    try {
-      let span
-      server.route({
-        method: 'POST',
-        path: '/',
-        handler: (request, h) => {
-          span = request.span
-          throw Error('testing')
-        },
-        options: {
-          id: 'test_route',
-          tags: ['sampled']
-        }
-      })
+  // await pluginTest.test('handle an fspiop error', async assert => {
+  //   try {
+  //     let span
+  //     server.route({
+  //       method: 'POST',
+  //       path: '/',
+  //       handler: (request, h) => {
+  //         span = request.span
+  //         throw Error('testing')
+  //       },
+  //       options: {
+  //         id: 'test_route',
+  //         tags: ['sampled']
+  //       }
+  //     })
 
-      const response = await server.inject({
-        method: 'POST',
-        url: '/'
-      })
+  //     const response = await server.inject({
+  //       method: 'POST',
+  //       url: '/'
+  //     })
 
-      assert.equal(response.statusCode, 500, 'status code is correct')
-      assert.ok(span)
-      assert.ok(span.isFinished)
-      assert.equal(span.spanContext.service, 'test_route')
-      assert.end()
-    } catch (e) {
-      assert.fail()
-      assert.end()
-    }
-  })
+  //     assert.equal(response.statusCode, 500, 'status code is correct')
+  //     assert.ok(span)
+  //     assert.ok(span.isFinished)
+  //     assert.equal(span.spanContext.service, 'test_route')
+  //     assert.end()
+  //   } catch (e) {
+  //     assert.fail()
+  //     assert.end()
+  //   }
+  // })
 
   await pluginTest.end()
 })


### PR DESCRIPTION
Fixes #1101

- Upgrade `event-sdk` to `v8.6.1`, and add missing `tracestate` header which is now required to parse the context
- Bump package version to `8.6.4`