### PR TITLE
fix(openapiBackend): Removed logger from `validationFail` function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "11.1.1",
+  "version": "11.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "11.1.1",
+  "version": "11.1.2",
   "description": "Shared code for central services",
   "main": "src/index.js",
   "scripts": {

--- a/src/util/openapiBackend.js
+++ b/src/util/openapiBackend.js
@@ -23,7 +23,6 @@
  ******/
 'use strict'
 
-const Logger = require('@mojaloop/central-services-logger')
 const ErrorHandler = require('@mojaloop/central-services-error-handling')
 const OpenAPIBackend = require('openapi-backend').default
 const OpenAPIValidator = require('openapi-backend').OpenAPIValidator
@@ -65,9 +64,7 @@ const initialise = async (definitionPath, handlers, ajvOpts = { $data: true, coe
  * @throws {FSPIOPError}
  */
 const validationFail = async (context) => {
-  Logger.info('Validation Error')
   const fspiopError = ErrorHandler.Factory.createFSPIOPErrorFromOpenapiError(context.validation.errors[0])
-  Logger.error(fspiopError)
   throw fspiopError
 }
 


### PR DESCRIPTION
I don't like having logging in this function, since it can't be easily configured by someone using this library.

If someone wants to add logging back in, they could simply write a wrapper around this function in their own implementation.

I also noticed that there was no logging elsewhere in this file.