### PR TITLE
 chore: add 'example' as whitelisted keyword

### DIFF
--- a/src/util/openapiBackend.js
+++ b/src/util/openapiBackend.js
@@ -34,7 +34,7 @@ const initialise = async (definitionPath, handlers, ajvOpts = { $data: true, coe
     ajvOpts.coerceTypes = true
   }
   const ajv = new Ajv(ajvOpts)
-  await require('ajv-keywords')(ajv)
+  await require('ajv-keywords')(ajv, ["example"])
   const api = new OpenAPIBackend({
     definition: definitionPath,
     strict: false,

--- a/src/util/openapiBackend.js
+++ b/src/util/openapiBackend.js
@@ -34,7 +34,8 @@ const initialise = async (definitionPath, handlers, ajvOpts = { $data: true, coe
     ajvOpts.coerceTypes = true
   }
   const ajv = new Ajv(ajvOpts)
-  await require('ajv-keywords')(ajv, ["example"])
+  ajv.addVocabulary(["example"])
+  await require('ajv-keywords')(ajv)
   const api = new OpenAPIBackend({
     definition: definitionPath,
     strict: false,


### PR DESCRIPTION
`ajv` in `openapi-backed` in `central-services-shared` really hates `example` fields in openapi3 and thats what is causing tests to explode with central-services-shared>11.5.9 for some of the PISP services.

Now I don't know much about the justification of ajv in openapi-backend, keywords etc, and if I should be adding this keyword. I can always remove our `example` fields from `api-snippets` but I'd rather not do that.