### PR TITLE
chore: resolve shin and urijs vulnerabilities

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -1,41 +1,21 @@
 {
   "decisions": {
+    "1766|widdershins>urijs": {
+      "decision": "fix",
+      "madeAt": 1627877107764
+    },
     "1500|widdershins>yargs>yargs-parser": {
       "decision": "ignore",
-      "madeAt": 1623755999183,
-      "expiresAt": 1626347994107
-    },
-    "1640|widdershins>urijs": {
-      "decision": "fix",
-      "madeAt": 1615187901100
-    },
-    "1654|@mojaloop/event-sdk>grpc>protobufjs>yargs>y18n": {
-      "decision": "fix",
-      "madeAt": 1620391401423
-    },
-    "1654|widdershins>yargs>y18n": {
-      "decision": "fix",
-      "madeAt": 1620391421241
-    },
-    "1673|@mojaloop/event-sdk>lodash": {
-      "decision": "ignore",
-      "madeAt": 1620357960127,
-      "expiresAt": 1622949946141
+      "madeAt": 1627877040831,
+      "expiresAt": 1630469028768
     },
     "1675|shins>sanitize-html": {
       "decision": "ignore",
-      "madeAt": 1623756000737,
-      "expiresAt": 1626347994107
+      "madeAt": 1627877046520
     },
     "1676|shins>sanitize-html": {
       "decision": "ignore",
-      "madeAt": 1623756000737,
-      "expiresAt": 1626347994107
-    },
-    "1693|shins>sanitize-html>postcss": {
-      "decision": "ignore",
-      "madeAt": 1623756002194,
-      "expiresAt": 1626347994107
+      "madeAt": 1627877046520
     }
   },
   "rules": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "13.0.5",
+  "version": "13.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9759,9 +9759,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
-      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "13.0.5",
+  "version": "13.0.6",
   "description": "Shared code for mojaloop central services",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
https://github.com/mojaloop/project/issues/2354

https://github.com/Mermade/shins is no longer being supported so theres no nice solution to the vulnerability other than permanently ignore it for now.
I don't see an easy way to update `shins` to https://github.com/Mermade/reslate either.