### PR TITLE
feat: add a new action enum for `RESERVED_ABORTED`

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -24,6 +24,21 @@
       "decision": "ignore",
       "madeAt": 1636372055094,
       "expiresAt": 1638964045850
+    },
+    "1004809|widdershins>openapi-sampler>json-pointer": {
+      "decision": "ignore",
+      "madeAt": 1636956486789,
+      "expiresAt": 1639548471465
+    },
+    "1004812|widdershins>swagger2openapi>better-ajv-errors>jsonpointer": {
+      "decision": "ignore",
+      "madeAt": 1636956491233,
+      "expiresAt": 1639548471465
+    },
+    "1004812|widdershins>swagger2openapi>oas-validator>better-ajv-errors>jsonpointer": {
+      "decision": "ignore",
+      "madeAt": 1636956491233,
+      "expiresAt": 1639548471465
     }
   },
   "rules": {},

--- a/src/enums/events.js
+++ b/src/enums/events.js
@@ -93,6 +93,10 @@ const Event = {
     RECORD_FUNDS_OUT_PREPARE_RESERVE: 'recordFundsOutPrepareReserve',
     REJECT: 'reject',
     RESOLVE: 'resolve',
+    
+    // The Transfer was marked as RESERVED by the payee DFSP
+    // and was then aborted by the switch
+    RESERVED_ABORTED: 'reserved-aborted',
     REQUEST: 'request',
     RESERVE: 'reserve',
     SETTLEMENT_WINDOW: 'settlement-window',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -260,6 +260,7 @@ declare namespace CentralServicesShared {
   enum EventActionEnum {
     ABORT = 'abort',
     ABORT_DUPLICATE = 'abort-duplicate',
+    ABORT_VALIDATION = 'abort-validation',
     ACCEPT = 'accept',
     BULK_ABORT = 'bulk-abort',
     BULK_COMMIT = 'bulk-commit',
@@ -294,6 +295,7 @@ declare namespace CentralServicesShared {
     RESOLVE = 'resolve',
     REQUEST = 'request',
     RESERVE = 'reserve',
+    RESERVED_ABORTED = 'reserved-aborted',
     SETTLEMENT_WINDOW = 'settlement-window',
     TIMEOUT_RECEIVED = 'timeout-received',
     TIMEOUT_RESERVED = 'timeout-reserved',
@@ -317,6 +319,7 @@ declare namespace CentralServicesShared {
         Action: {
           ABORT: EventActionEnum.ABORT;
           ABORT_DUPLICATE: EventActionEnum.ABORT_DUPLICATE;
+          ABORT_VALIDATION: EventActionEnum.ABORT_VALIDATION;
           ACCEPT: EventActionEnum.ACCEPT;
           BULK_ABORT: EventActionEnum.BULK_ABORT;
           BULK_COMMIT: EventActionEnum.BULK_COMMIT;
@@ -351,6 +354,7 @@ declare namespace CentralServicesShared {
           RESOLVE: EventActionEnum.RESOLVE;
           REQUEST: EventActionEnum.REQUEST;
           RESERVE: EventActionEnum.RESERVE;
+          RESERVED_ABORTED: EventActionEnum.RESERVED_ABORTED;
           SETTLEMENT_WINDOW: EventActionEnum.SETTLEMENT_WINDOW;
           TIMEOUT_RECEIVED: EventActionEnum.TIMEOUT_RECEIVED;
           TIMEOUT_RESERVED: EventActionEnum.TIMEOUT_RESERVED;


### PR DESCRIPTION
Let me know if you can think of a better name for this event.


Vuln log:

```

> @mojaloop/central-services-shared@15.0.1 audit:resolve /home/lew/developer/mojaloop/central-services-shared
> SHELL=sh resolve-audit --production

>>>> npm audit --json --production
>>>> exit: 1
skipping issues in ansi-regex based on decisions: "ignore" from audit-resolve.json
skipping issues in sanitize-html based on decisions: "ignore" from audit-resolve.json
skipping issues in yargs-parser based on decisions: "ignore" from audit-resolve.json

--------------------------------------------------
 jsonpointer needs your attention.

[ moderate ] Prototype Pollution in node-jsonpointer
 vulnerable versions <5.0.0 found in:
 - dependencies: widdershins>swagger2openapi>better-ajv-errors>jsonpointer
 - dependencies: widdershins>swagger2openapi>oas-validator>better-ajv-errors>jsonpointer
_
 d) show more details and ask me again
 r) remind me in 24h
 i) ignore paths
 del) Remove all listed dependency paths
 s) Skip this
 q) Quit
What would you like to do? i

 You can ignore permanently or decide to revisit later
_
 M) ignore for a month
 W) ignore for a week
 !) ignore permanently
 s) Skip this
 q) Quit
What would you like to do? M
```