### PR TITLE
feat(mojaloop/#2608): injected resource versions config for outbound requests

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -39,6 +39,46 @@
       "decision": "ignore",
       "madeAt": 1636956491233,
       "expiresAt": 1639548471465
+    },
+    "1004854|widdershins>openapi-sampler>json-pointer": {
+      "decision": "ignore",
+      "madeAt": 1637925238134,
+      "expiresAt": 1640517233443
+    },
+    "1004869|widdershins>swagger2openapi>better-ajv-errors>jsonpointer": {
+      "decision": "ignore",
+      "madeAt": 1637925239670,
+      "expiresAt": 1640517233443
+    },
+    "1004869|widdershins>swagger2openapi>oas-validator>better-ajv-errors>jsonpointer": {
+      "decision": "ignore",
+      "madeAt": 1637925239670,
+      "expiresAt": 1640517233443
+    },
+    "1004946|widdershins>yargs>string-width>strip-ansi>ansi-regex": {
+      "decision": "ignore",
+      "madeAt": 1637925241156,
+      "expiresAt": 1640517233443
+    },
+    "1004946|widdershins>yargs>cliui>string-width>strip-ansi>ansi-regex": {
+      "decision": "ignore",
+      "madeAt": 1637925241156,
+      "expiresAt": 1640517233443
+    },
+    "1005383|shins>sanitize-html": {
+      "decision": "ignore",
+      "madeAt": 1637925243300,
+      "expiresAt": 1640517233443
+    },
+    "1005384|shins>sanitize-html": {
+      "decision": "ignore",
+      "madeAt": 1637925243300,
+      "expiresAt": 1640517233443
+    },
+    "1005534|widdershins>yargs>yargs-parser": {
+      "decision": "ignore",
+      "madeAt": 1637925244682,
+      "expiresAt": 1640517233443
     }
   },
   "rules": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1257,14 +1257,14 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.6.tgz",
-      "integrity": "sha512-e42bVZnC6VluBZBAFEr3YrdqSspG3bgilyg4nSLBJ7TRGNCzxHa92XAHxQBLYg0BmgwO4b2mf3h/l5EkEWRn3g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-2.0.0.tgz",
+      "integrity": "sha512-fSan/Pu11xS/TdaTpTB0MRn9guwGU8dye+x56mEVgBEd/QsybBbYcAL0phPXi8SGWFEChkQd6M9qL4y6VOpFig==",
       "dev": true,
       "requires": {
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
-        "node-gyp": "^7.1.0",
+        "node-gyp": "^8.2.0",
         "read-package-json-fast": "^2.0.1"
       }
     },
@@ -1541,9 +1541,9 @@
       }
     },
     "ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -1560,9 +1560,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.0.0.tgz",
-      "integrity": "sha512-ULd1QMjRoH6JDNUQIfDLrlE+OgZlFaxyYCjzt58uNuUQtKXt8/U+vK/8Ql0gyn/C5mqZzUWtKMqr/4YquvTrWA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3"
@@ -1966,21 +1966,6 @@
         "optjs": "~3.2.2"
       }
     },
-    "asn1": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-      "dev": true,
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -2050,18 +2035,6 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
-      "dev": true
-    },
     "axios": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
@@ -2086,15 +2059,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bath-es5/-/bath-es5-3.0.3.tgz",
       "integrity": "sha512-PdCioDToH3t84lP40kUFCKWCOCH389Dl1kbC8FGoqOwamxsmqxxnJSXdkTOsPoNHXjem4+sJ+bbNoQm5zeCqxg=="
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "better-ajv-errors": {
       "version": "0.6.7",
@@ -2210,9 +2174,9 @@
           }
         },
         "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
+          "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==",
           "dev": true
         },
         "chalk": {
@@ -2452,12 +2416,6 @@
       "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
       "dev": true
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -2580,19 +2538,35 @@
       }
     },
     "cli-table": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
-      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.9.tgz",
+      "integrity": "sha512-7eA6hFtAZwVx3dWAGoaBqTrzWko5jRUFKpHT64ZHkJpaA3y5wf5NlLjguqTRmqycatJZiwftODYYyGNLbQ7MuA==",
       "dev": true,
       "requires": {
-        "colors": "1.0.3"
+        "colors": "1.0.3",
+        "strip-ansi": "^6.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "colors": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
         }
       }
     },
@@ -2673,6 +2647,12 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
     },
     "colorette": {
       "version": "1.2.2",
@@ -3157,15 +3137,6 @@
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -3210,6 +3181,37 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
+      "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "es-get-iterator": "^1.1.1",
+        "get-intrinsic": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
       }
     },
     "deep-extend": {
@@ -3260,6 +3262,12 @@
           "dev": true
         }
       }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -3459,16 +3467,6 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -3596,22 +3594,26 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
         "has-symbols": "^1.0.2",
-        "is-callable": "^1.2.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.3",
-        "is-string": "^1.0.6",
-        "object-inspect": "^1.10.3",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
@@ -3619,10 +3621,25 @@
         "unbox-primitive": "^1.0.1"
       },
       "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+          "dev": true
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
           "dev": true
         }
       }
@@ -4336,12 +4353,6 @@
         }
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
     "extensible-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extensible-error/-/extensible-error-1.0.2.tgz",
@@ -4358,12 +4369,6 @@
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -4608,12 +4613,6 @@
           }
         }
       }
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
     },
     "form-data": {
       "version": "3.0.0",
@@ -4902,15 +4901,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "git-raw-commits": {
@@ -5313,17 +5303,6 @@
         }
       }
     },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
     "http2-client": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.3.tgz",
@@ -5456,9 +5435,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
-      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-4.0.1.tgz",
+      "integrity": "sha512-rzDQLaW4jQbh2YrOFlJdCtX8qgJTehFRYiUB2r1osqTeDzV/3+Jh8fz1oAPzUThf3iku8Ds4IDqawI5d8mUiQw==",
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
@@ -5825,13 +5804,13 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.2"
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-regexp": {
@@ -5891,71 +5870,6 @@
         "es-abstract": "^1.18.5",
         "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.1.1",
-            "get-symbol-description": "^1.0.0",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.2",
-            "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.4",
-            "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.4",
-            "is-string": "^1.0.7",
-            "object-inspect": "^1.11.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
-          }
-        },
-        "is-callable": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-          }
-        },
-        "is-string": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-          "dev": true,
-          "requires": {
-            "has-tostringtag": "^1.0.0"
-          }
-        },
-        "object-inspect": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
       }
     },
     "is-typedarray": {
@@ -6012,12 +5926,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.0.0",
@@ -6208,12 +6116,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6254,12 +6156,6 @@
       "requires": {
         "foreach": "^2.0.4"
       }
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
     },
     "json-schema-traverse": {
       "version": "1.0.0",
@@ -6347,18 +6243,6 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
-      }
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
       }
     },
     "jsx-ast-utils": {
@@ -7274,23 +7158,68 @@
       }
     },
     "node-gyp": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
-      "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
       "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.3",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
         "nopt": "^5.0.0",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.2",
+        "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.2",
-        "tar": "^6.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
         "which": "^2.0.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+          "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "gauge": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.0.tgz",
+          "integrity": "sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1",
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.1",
+            "signal-exit": "^3.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wide-align": "^1.1.2"
+          }
+        },
+        "npmlog": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.0.tgz",
+          "integrity": "sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==",
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^4.0.0",
+            "set-blocking": "^2.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7298,6 +7227,26 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         },
         "which": {
@@ -7418,9 +7367,9 @@
       }
     },
     "npm-check-updates": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-12.0.0.tgz",
-      "integrity": "sha512-KkUu9W5BWE4JmNeuPEwDz5a5yBOoWSrWl4DbT1/jBm+ytpVzjO9NN2jAD0GydhHZV/Brgh4xgWtBiMZJi5dUxQ==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-12.0.2.tgz",
+      "integrity": "sha512-VzMNuUXqRta1qpBkFiE0hKfpOGP2FbYwpBBTcJXoJWppOPBSi/paWFVhPVWf7PgRoDWegK+PDAWKhIvhyrBrIg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
@@ -7439,7 +7388,7 @@
         "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "p-map": "^4.0.0",
-        "pacote": "^11.3.5",
+        "pacote": "^12.0.2",
         "parse-github-url": "^1.0.2",
         "progress": "^2.0.3",
         "prompts": "^2.4.2",
@@ -7448,7 +7397,7 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "semver-utils": "^1.1.4",
-        "source-map-support": "^0.5.19",
+        "source-map-support": "^0.5.20",
         "spawn-please": "^1.0.0",
         "update-notifier": "^5.1.0"
       },
@@ -7605,13 +7554,13 @@
       }
     },
     "npm-packlist": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-2.2.2.tgz",
-      "integrity": "sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-3.0.0.tgz",
+      "integrity": "sha512-L/cbzmutAwII5glUcf2DBRNY/d0TFd4e/FnaZigJV6JD85RHZXJFGwCndjMWiiViiWSsWt3tiOLpI3ByTnIdFQ==",
       "dev": true,
       "requires": {
         "glob": "^7.1.6",
-        "ignore-walk": "^3.0.3",
+        "ignore-walk": "^4.0.1",
         "npm-bundled": "^1.1.1",
         "npm-normalize-package-bin": "^1.0.1"
       }
@@ -8191,12 +8140,6 @@
         }
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -8217,6 +8160,12 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.2",
@@ -8770,15 +8719,15 @@
       }
     },
     "pacote": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
-      "integrity": "sha512-fT375Yczn4zi+6Hkk2TBe1x1sP8FgFsEIZ2/iWaXY2r/NkhDJfxbcn5paz1+RTFCyNf+dPnaoBDJoAxXSU8Bkg==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-12.0.2.tgz",
+      "integrity": "sha512-Ar3mhjcxhMzk+OVZ8pbnXdb0l8+pimvlsqBGRNkble2NVgyqOGE3yrCGi/lAYq7E7NRDMz89R1Wx5HIMCGgeYg==",
       "dev": true,
       "requires": {
         "@npmcli/git": "^2.1.0",
         "@npmcli/installed-package-contents": "^1.0.6",
         "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^1.8.2",
+        "@npmcli/run-script": "^2.0.0",
         "cacache": "^15.0.5",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
@@ -8786,7 +8735,7 @@
         "minipass": "^3.1.3",
         "mkdirp": "^1.0.3",
         "npm-package-arg": "^8.0.1",
-        "npm-packlist": "^2.1.4",
+        "npm-packlist": "^3.0.0",
         "npm-pick-manifest": "^6.0.0",
         "npm-registry-fetch": "^11.0.0",
         "promise-retry": "^2.0.1",
@@ -8897,12 +8846,6 @@
       "requires": {
         "through": "~2.3"
       }
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
     },
     "picomatch": {
       "version": "2.3.0",
@@ -9291,12 +9234,6 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
-    "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
-    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -9358,14 +9295,43 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
       "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.3",
+        "bytes": "3.1.1",
+        "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+          "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+        },
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+        },
+        "toidentifier": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+          "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+        }
       }
     },
     "rc": {
@@ -9635,53 +9601,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        }
-      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -10192,9 +10111,9 @@
       }
     },
     "socks-proxy-agent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
       "dev": true,
       "requires": {
         "agent-base": "^6.0.2",
@@ -10225,9 +10144,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -10339,23 +10258,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
     },
     "ssri": {
       "version": "8.0.1",
@@ -11033,14 +10935,14 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.4.tgz",
-      "integrity": "sha512-hWCk/iqf7lp0/AgTF7/ddO1IWtSNPASjlzCicV5irAVdE1grjsneK26YG6xACMBEdCvO8fUST0UzDMh/2Qy+9Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.5.tgz",
+      "integrity": "sha512-Lnh17webJVsD6ECeovpVN17RlAKjmz4rF9S+8Y45CkMc/ufVpTkU3vZIyIC7sllQ1FCvObZnnCdNs/HXTUOTlg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2"
+        "es-abstract": "^1.19.1"
       }
     },
     "string.prototype.trimend": {
@@ -11636,9 +11538,9 @@
       }
     },
     "tape": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.3.1.tgz",
-      "integrity": "sha512-Mj3h+/dgfI2xct4kTpzqZaRxhhglXcMg//xGTbB0AQisfiOYa6ZBNQIgv46xi1MqbgthuNLSS1SAySDZsb7MMA==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.3.2.tgz",
+      "integrity": "sha512-F+UjjvUJsEq/D0NwTKtuekTJsN7vpvYT/dvkZuBw7Y+2whC2JIU8syHIlNNkqstmtBu/mVoqhDr1QJGFUl+caA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
@@ -11647,7 +11549,7 @@
         "dotignore": "^0.1.2",
         "for-each": "^0.3.3",
         "get-package-type": "^0.1.0",
-        "glob": "^7.1.7",
+        "glob": "^7.2.0",
         "has": "^1.0.3",
         "has-dynamic-import": "^2.0.0",
         "inherits": "^2.0.4",
@@ -11658,65 +11560,28 @@
         "object.assign": "^4.1.2",
         "resolve": "^2.0.0-next.3",
         "resumer": "^0.0.0",
-        "string.prototype.trim": "^1.2.4",
+        "string.prototype.trim": "^1.2.5",
         "through": "^2.3.8"
       },
       "dependencies": {
-        "deep-equal": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.5.tgz",
-          "integrity": "sha512-nPiRgmbAtm1a3JsnLCf6/SLfXcjyN5v8L1TXzdCmHrXJ4hx+gW/w1YCcn7z8gJtSiDArZCgYtbao3QqLm/N1Sw==",
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
           "dev": true,
           "requires": {
-            "call-bind": "^1.0.0",
-            "es-get-iterator": "^1.1.1",
-            "get-intrinsic": "^1.0.1",
-            "is-arguments": "^1.0.4",
-            "is-date-object": "^1.0.2",
-            "is-regex": "^1.1.1",
-            "isarray": "^2.0.5",
-            "object-is": "^1.1.4",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "regexp.prototype.flags": "^1.3.0",
-            "side-channel": "^1.0.3",
-            "which-boxed-primitive": "^1.0.1",
-            "which-collection": "^1.0.1",
-            "which-typed-array": "^1.1.2"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
-        },
-        "defined": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
         },
         "object-inspect": {
           "version": "1.11.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
           "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
           "dev": true
         },
         "resolve": {
@@ -11867,16 +11732,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
     "traceparent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/traceparent/-/traceparent-1.0.0.tgz",
@@ -11937,21 +11792,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -12226,17 +12066,6 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -12287,71 +12116,6 @@
         "foreach": "^2.0.5",
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.7"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
-          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.1.1",
-            "get-symbol-description": "^1.0.0",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.2",
-            "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.4",
-            "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.4",
-            "is-string": "^1.0.7",
-            "object-inspect": "^1.11.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
-          }
-        },
-        "is-callable": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-          "dev": true
-        },
-        "is-regex": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "has-tostringtag": "^1.0.0"
-          }
-        },
-        "is-string": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-          "dev": true,
-          "requires": {
-            "has-tostringtag": "^1.0.0"
-          }
-        },
-        "object-inspect": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
       }
     },
     "widdershins": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8544,9 +8544,9 @@
       }
     },
     "openapi-backend": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.0.0.tgz",
-      "integrity": "sha512-ppOFSLEXIgmRGcbd9kfPzXmUFHhlBux69rlu7dot5XZ6BH7ycXEvFjRdFLXZ76GdO++i3epDZkxkRBHqPNoz/Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.0.1.tgz",
+      "integrity": "sha512-DHjQ7d3izTgIy6lSD+WGLhlunZ+fkyleHjNnUSGjHC7Lii3ukuB3N/J74NaCHf5mrDlXgCfylFMRVtq4oDwPKQ==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "ajv": "^8.6.2",
@@ -8569,20 +8569,20 @@
       }
     },
     "openapi-schema-validator": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-9.3.0.tgz",
-      "integrity": "sha512-KlvgZMWTu+H1FHFSZNAGj369uXl3BD1nXSIq+sXlG6P+OrsAHd3YORx0ZEZ3WGdu2LQrPGmtowGQavYXL+PLwg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-9.3.1.tgz",
+      "integrity": "sha512-5wpFKMoEbUcjiqo16jIen3Cb2+oApSnYZpWn8WQdRO2q/dNQZZl8Pz6ESwCriiyU5AK4i5ZI6+7O3bHQr6+6+g==",
       "requires": {
         "ajv": "^8.1.0",
         "ajv-formats": "^2.0.2",
         "lodash.merge": "^4.6.1",
-        "openapi-types": "^9.3.0"
+        "openapi-types": "^9.3.1"
       }
     },
     "openapi-types": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.0.tgz",
-      "integrity": "sha512-sR23YjmuwDSMsQVZDHbV9mPgi0RyniQlqR0AQxTC2/F3cpSjRFMH3CFPjoWvNqhC4OxPkDYNb2l8Mc1Me6D/KQ=="
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.3.1.tgz",
+      "integrity": "sha512-/Yvsd2D7miYB4HLJ3hOOS0+vnowQpaT75FsHzr/y5M9P4q9bwa7RcbW2YdH6KZBn8ceLbKGnHxMZ1CHliGHUFw=="
     },
     "opn": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "immutable": "4.0.0",
     "lodash": "4.17.21",
     "mustache": "4.2.0",
-    "openapi-backend": "5.0.0",
+    "openapi-backend": "5.0.1",
     "raw-body": "2.4.2",
     "rc": "1.2.8",
     "shins": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lodash": "4.17.21",
     "mustache": "4.2.0",
     "openapi-backend": "5.0.0",
-    "raw-body": "2.4.1",
+    "raw-body": "2.4.2",
     "rc": "1.2.8",
     "shins": "2.6.0",
     "uuid4": "2.0.2",
@@ -72,12 +72,12 @@
     "@mojaloop/central-services-metrics": "11.0.0",
     "@mojaloop/event-sdk": "10.7.1",
     "@mojaloop/sdk-standard-components": "10.3.2",
-    "ajv": "8.6.3",
-    "ajv-keywords": "5.0.0",
+    "ajv": "8.8.2",
+    "ajv-keywords": "5.1.0",
     "base64url": "3.0.1",
     "chance": "1.1.8",
     "npm-audit-resolver": "2.3.1",
-    "npm-check-updates": "12.0.0",
+    "npm-check-updates": "12.0.2",
     "nyc": "15.1.0",
     "pre-commit": "1.2.2",
     "proxyquire": "2.1.3",
@@ -87,7 +87,7 @@
     "standard-version": "9.3.2",
     "tap-spec": "^5.0.0",
     "tap-xunit": "2.4.1",
-    "tape": "5.3.1",
+    "tape": "5.3.2",
     "tapes": "4.1.0"
   },
   "peerDependencies": {
@@ -95,8 +95,8 @@
     "@mojaloop/central-services-logger": "10.6.2",
     "@mojaloop/central-services-metrics": "11.0.0",
     "@mojaloop/event-sdk": "10.7.1",
-    "ajv": "8.6.3",
-    "ajv-keywords": "5.0.0"
+    "ajv": "8.8.2",
+    "ajv-keywords": "5.1.0"
   },
   "peerDependenciesMeta": {
     "@mojaloop/central-services-error-handling": {

--- a/src/enums/events.js
+++ b/src/enums/events.js
@@ -93,7 +93,7 @@ const Event = {
     RECORD_FUNDS_OUT_PREPARE_RESERVE: 'recordFundsOutPrepareReserve',
     REJECT: 'reject',
     RESOLVE: 'resolve',
-    
+
     // The Transfer was marked as RESERVED by the payee DFSP
     // and was then aborted by the switch
     RESERVED_ABORTED: 'reserved-aborted',

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -403,8 +403,13 @@ declare namespace CentralServicesShared {
     getEndpointAndRender(switchUrl: string, fsp: string, endpointType: FspEndpointTypesEnum, path: string, options?: any): Promise<string>
   }
 
+  interface ProtocolVersionsType {
+    content: string,
+    accept: string
+  }
+  
   interface Request {
-    sendRequest(url: string, headers: HapiUtil.Dictionary<string>, source: string, destination: string, method?: RestMethodsEnum, payload?: any, responseType?: string, span?: any, jwsSigner?: any): Promise<any>
+    sendRequest(url: string, headers: HapiUtil.Dictionary<string>, source: string, destination: string, method?: RestMethodsEnum, payload?: any, responseType?: string, span?: any, jwsSigner?: any, protocolVersions?: ProtocolVersionsType): Promise<any>
   }
 
   interface Kafka {

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -43,20 +43,26 @@ delete request.defaults.headers.common.Accept
  *
  * @description sends a request to url
  *
+ * @typedef SendRequestProtocolVersions
+ * @type {object}
+ * @property {string} content - protocol version to be used in the ContentType HTTP Header.
+ * @property {string} accept - protocol version to be used in the Accept HTTP Header.
+ *
  * @param {string} url the endpoint for the service you require
  * @param {object} headers the http headers
  * @param {string} method http method being requested i.e. GET, POST, PUT
  * @param {string} source id for which callback is being sent from
  * @param {string} destination id for which callback is being sent
- * @param {object} payload the body of the request being sent
+ * @param {object | undefined} payload the body of the request being sent
  * @param {string} responseType the type of the response object
- * @param {object} span a span for event logging if this request is within a span
- * @param {object} jwsSigner the jws signer for signing the requests
+ * @param {object | undefined} span a span for event logging if this request is within a span
+ * @param {object | undefined} jwsSigner the jws signer for signing the requests
+ * @param {SendRequestProtocolVersions | undefined} protocolVersions the config for Protocol versions to be used
  *
- *@return {object} The response for the request being sent or error object with response included
+ *@return {Promise<any>} The response for the request being sent or error object with response included
  */
 
-const sendRequest = async (url, headers, source, destination, method = enums.Http.RestMethods.GET, payload = undefined, responseType = enums.Http.ResponseTypes.JSON, span = undefined, jwsSigner = undefined) => {
+const sendRequest = async (url, headers, source, destination, method = enums.Http.RestMethods.GET, payload = undefined, responseType = enums.Http.ResponseTypes.JSON, span = undefined, jwsSigner = undefined, protocolVersions = undefined) => {
   const histTimerEnd = !!Metrics.isInitiated() && Metrics.getHistogram(
     'sendRequest',
     `sending ${method} request to: ${url} from: ${source} to: ${destination}`,
@@ -75,7 +81,8 @@ const sendRequest = async (url, headers, source, destination, method = enums.Htt
     const transformedHeaders = Headers.transformHeaders(headers, {
       httpMethod: method,
       sourceFsp: source,
-      destinationFsp: destination
+      destinationFsp: destination,
+      protocolVersions
     })
     requestOptions = {
       url,

--- a/test/unit/headers/transformer.test.js
+++ b/test/unit/headers/transformer.test.js
@@ -127,6 +127,7 @@ Test('Transfer Transformer tests', TransformerTest => {
 
     transformHeadersTest.test('Set ContentType && Accept versions via config', async test => {
       const RESOURCE_VERSIONS_BACKUP = process.env.RESOURCE_VERSIONS
+      // we keep this here to make sure it does not override the injected protocolVersions config
       process.env.RESOURCE_VERSIONS = 'transfers=1.0,quotes=1.0'
 
       const headerConfig = {

--- a/test/unit/headers/transformer.test.js
+++ b/test/unit/headers/transformer.test.js
@@ -31,6 +31,7 @@ const Sinon = require('sinon')
 const Transformer = require('../../../src/util').Headers
 const Enum = require('../../../src/enums')
 const Util = require('../../../src/util')
+const Helper = require('../../util/helper')
 
 const headerConfigExample = {
   httpMethod: 'PUT',
@@ -54,8 +55,6 @@ const headerDataTransformedExample = {
   'FSPIOP-Destination': headerDataInputExample['FSPIOP-Destination']
 }
 
-const generateProtocolHeader = (resource, version) => `application/vnd.interoperability.${resource}+json;version=${version}`
-
 Test('Transfer Transformer tests', TransformerTest => {
   let sandbox
 
@@ -72,7 +71,7 @@ Test('Transfer Transformer tests', TransformerTest => {
   TransformerTest.test('Transformer.getResourceInfoFromHeaderTest() should', getResourceInfoFromHeaderTest => {
     getResourceInfoFromHeaderTest.test('parse FSPIOP Content-Type example correctly', async test => {
       const result = Transformer.getResourceInfoFromHeader(headerDataInputExample['Content-Type'])
-      test.equal(headerDataInputExample['Content-Type'], generateProtocolHeader(result.resourceType, result.version))
+      test.equal(headerDataInputExample['Content-Type'], Helper.generateProtocolHeader(result.resourceType, result.version))
       test.end()
     })
 
@@ -115,7 +114,7 @@ Test('Transfer Transformer tests', TransformerTest => {
       }
 
       const headerData = Util.clone(headerDataInputExample)
-      headerData.Accept = generateProtocolHeader('transfers', '1')
+      headerData.Accept = Helper.generateProtocolHeader('transfers', '1')
 
       const transformedHeaderData = Transformer.transformHeaders(headerData, headerConfig)
 
@@ -141,7 +140,7 @@ Test('Transfer Transformer tests', TransformerTest => {
       }
 
       const headerData = Util.clone(headerDataInputExample)
-      headerData.Accept = generateProtocolHeader('transfers', '1.1')
+      headerData.Accept = Helper.generateProtocolHeader('transfers', '1.1')
 
       const resourceInfoFromHeader = Transformer.getResourceInfoFromHeader(headerData['Content-Type'])
 
@@ -151,7 +150,7 @@ Test('Transfer Transformer tests', TransformerTest => {
       test.equal(resourceInfoFromHeader.resourceType, resourceInfoFromTransformedHeader.resourceType)
       test.equal(resourceInfoFromHeader.version, '1.0')
       test.equal(resourceInfoFromTransformedHeader.version, '1.1')
-      test.equal(transformedHeaderData.Accept, generateProtocolHeader('transfers', headerConfig.protocolVersions.accept))
+      test.equal(transformedHeaderData.Accept, Helper.generateProtocolHeader('transfers', headerConfig.protocolVersions.accept))
       test.end()
       process.env.RESOURCE_VERSIONS = RESOURCE_VERSIONS_BACKUP
     })

--- a/test/unit/headers/transformer.test.js
+++ b/test/unit/headers/transformer.test.js
@@ -54,6 +54,8 @@ const headerDataTransformedExample = {
   'FSPIOP-Destination': headerDataInputExample['FSPIOP-Destination']
 }
 
+const generateProtocolHeader = (resource, version) => `application/vnd.interoperability.${resource}+json;version=${version}`
+
 Test('Transfer Transformer tests', TransformerTest => {
   let sandbox
 
@@ -67,6 +69,30 @@ Test('Transfer Transformer tests', TransformerTest => {
     t.end()
   })
 
+  TransformerTest.test('Transformer.getResourceInfoFromHeaderTest() should', getResourceInfoFromHeaderTest => {
+    getResourceInfoFromHeaderTest.test('parse FSPIOP Content-Type example correctly', async test => {
+      const result = Transformer.getResourceInfoFromHeader(headerDataInputExample['Content-Type'])
+      test.equal(headerDataInputExample['Content-Type'], generateProtocolHeader(result.resourceType, result.version))
+      test.end()
+    })
+
+    getResourceInfoFromHeaderTest.test('return an empty result with standard application/json', async test => {
+      const contentType = 'application/json'
+      const result = Transformer.getResourceInfoFromHeader(contentType)
+      test.same(result, {})
+      test.end()
+    })
+
+    getResourceInfoFromHeaderTest.test('return an empty result with incorrect FSPIOP Content-Type input', async test => {
+      const contentType = 'application/vnd.interoperability.transfers+json'
+      const result = Transformer.getResourceInfoFromHeader(contentType)
+      test.same(result, {})
+      test.end()
+    })
+
+    getResourceInfoFromHeaderTest.end()
+  })
+
   TransformerTest.test('Transformer.transformHeaders() should', transformHeadersTest => {
     transformHeadersTest.test('Remove all unnecessary fields from Header', async test => {
       const headerData = Util.clone(headerDataInputExample)
@@ -76,6 +102,57 @@ Test('Transfer Transformer tests', TransformerTest => {
       }
       test.equals(transformedHeaderData[Enum.Http.Headers.GENERAL.CONTENT_LENGTH], undefined)
       test.end()
+    })
+
+    transformHeadersTest.test('Set ContentType && Accept versions via RESOURCE_VERSIONS env variable', async test => {
+      const RESOURCE_VERSIONS_BACKUP = process.env.RESOURCE_VERSIONS
+      process.env.RESOURCE_VERSIONS = 'transfers=1.1,quotes=1.0'
+
+      const headerConfig = {
+        httpMethod: 'PUT',
+        sourceFsp: 'switch',
+        destinationFsp: 'FSPDest'
+      }
+
+      const headerData = Util.clone(headerDataInputExample)
+      headerData.Accept = generateProtocolHeader('transfers', '1')
+
+      const transformedHeaderData = Transformer.transformHeaders(headerData, headerConfig)
+
+      test.deepEqual(headerData['Content-Type'], transformedHeaderData['Content-Type'])
+      test.deepEqual(headerData.Accept, transformedHeaderData.Accept)
+      test.end()
+      process.env.RESOURCE_VERSIONS = RESOURCE_VERSIONS_BACKUP
+    })
+
+    transformHeadersTest.test('Set ContentType && Accept versions via config', async test => {
+      const RESOURCE_VERSIONS_BACKUP = process.env.RESOURCE_VERSIONS
+      process.env.RESOURCE_VERSIONS = 'transfers=1.0,quotes=1.0'
+
+      const headerConfig = {
+        httpMethod: 'PUT',
+        sourceFsp: 'switch',
+        destinationFsp: 'FSPDest',
+        protocolVersions: {
+          content: '1.1',
+          accept: '1'
+        }
+      }
+
+      const headerData = Util.clone(headerDataInputExample)
+      headerData.Accept = generateProtocolHeader('transfers', '1.1')
+
+      const resourceInfoFromHeader = Transformer.getResourceInfoFromHeader(headerData['Content-Type'])
+
+      const transformedHeaderData = Transformer.transformHeaders(headerData, headerConfig)
+      const resourceInfoFromTransformedHeader = Transformer.getResourceInfoFromHeader(transformedHeaderData['Content-Type'])
+
+      test.equal(resourceInfoFromHeader.resourceType, resourceInfoFromTransformedHeader.resourceType)
+      test.equal(resourceInfoFromHeader.version, '1.0')
+      test.equal(resourceInfoFromTransformedHeader.version, '1.1')
+      test.equal(transformedHeaderData.Accept, generateProtocolHeader('transfers', headerConfig.protocolVersions.accept))
+      test.end()
+      process.env.RESOURCE_VERSIONS = RESOURCE_VERSIONS_BACKUP
     })
 
     transformHeadersTest.test('Translate Date field into correct format for String value', async test => {

--- a/test/unit/util/request.test.js
+++ b/test/unit/util/request.test.js
@@ -112,6 +112,59 @@ Test('ParticipantEndpoint Model Test', modelTest => {
       }
     })
 
+    getEndpointTest.test('handle protocolVersions for config injection', async (test) => {
+      const protocolVersions = {
+        content: '2.1',
+        accept: '2'
+      }
+      const fsp = 'fsp'
+      const requestOptions = {
+        url: Mustache.render(Config.ENDPOINT_SOURCE_URL + Enum.EndPoints.FspEndpointTemplates.PARTICIPANT_ENDPOINTS_GET, { fsp }),
+        method: 'get'
+      }
+      const requestFunction = (request) => {
+        test.equal(request.headers['content-type'], Helper.generateProtocolHeader('participants', protocolVersions.content))
+        test.equal(request.headers.accept, Helper.generateProtocolHeader('participants', protocolVersions.accept))
+        return Helper.getEndPointsResponse
+      }
+      const span = EventSdk.Tracer.createSpan('test-span')
+      Model = proxyquire('../../../src/util/request', { axios: requestFunction })
+
+      try {
+        const result = await Model.sendRequest(requestOptions.url, Helper.defaultHeaders(Enum.Http.HeaderResources.SWITCH, Enum.Http.HeaderResources.PARTICIPANTS, Enum.Http.HeaderResources.SWITCH), Enum.Http.HeaderResources.SWITCH, Enum.Http.HeaderResources.SWITCH, Enum.Http.RestMethods.GET, undefined, Enum.Http.ResponseTypes.JSON, span, null, protocolVersions)
+        test.deepEqual(result, Helper.getEndPointsResponse, 'The results match')
+        test.end()
+      } catch (err) {
+        test.fail('Error thrown', err)
+        test.end()
+      }
+    })
+
+    getEndpointTest.test('handle protocolVersions without config injection', async (test) => {
+      const protocolVersions = null
+      const fsp = 'fsp'
+      const requestOptions = {
+        url: Mustache.render(Config.ENDPOINT_SOURCE_URL + Enum.EndPoints.FspEndpointTemplates.PARTICIPANT_ENDPOINTS_GET, { fsp }),
+        method: 'get'
+      }
+      const requestFunction = (request) => {
+        test.equal(request.headers['content-type'], Helper.generateProtocolHeader('participants', '1.0'))
+        test.equal(request.headers.accept, Helper.generateProtocolHeader('participants', '1'))
+        return Helper.getEndPointsResponse
+      }
+      const span = EventSdk.Tracer.createSpan('test-span')
+      Model = proxyquire('../../../src/util/request', { axios: requestFunction })
+
+      try {
+        const result = await Model.sendRequest(requestOptions.url, Helper.defaultHeaders(Enum.Http.HeaderResources.SWITCH, Enum.Http.HeaderResources.PARTICIPANTS, Enum.Http.HeaderResources.SWITCH), Enum.Http.HeaderResources.SWITCH, Enum.Http.HeaderResources.SWITCH, Enum.Http.RestMethods.GET, undefined, Enum.Http.ResponseTypes.JSON, span, null, protocolVersions)
+        test.deepEqual(result, Helper.getEndPointsResponse, 'The results match')
+        test.end()
+      } catch (err) {
+        test.fail('Error thrown', err)
+        test.end()
+      }
+    })
+
     getEndpointTest.test('throw error', async (test) => {
       const fsp = 'fsp1'
 

--- a/test/util/helper.js
+++ b/test/util/helper.js
@@ -26,13 +26,15 @@
 
 const Enums = require('../../src/enums')
 
-function defaultHeaders (destination, resource, source, version = '1.0') {
+const generateProtocolHeader = (resource, version) => `application/vnd.interoperability.${resource}+json;version=${version}`
+
+const defaultHeaders = (destination, resource, source, version = '1.0') => {
   // TODO: See API section 3.2.1; what should we do about X-Forwarded-For? Also, should we
   // add/append to this field in all 'queueResponse' calls?
   return {
-    accept: `application/vnd.interoperability.${resource}+json;version=${version}`,
+    accept: generateProtocolHeader(resource, version),
     'fspiop-destination': destination || '',
-    'content-type': `application/vnd.interoperability.${resource}+json;version=${version}`,
+    'content-type': generateProtocolHeader(resource, version),
     date: '2019-05-24 08:52:19',
     'fspiop-source': source
   }
@@ -74,6 +76,7 @@ const getEndpointAndRenderResponse = {
 
 module.exports = {
   defaultHeaders,
+  generateProtocolHeader,
   getEndPointsResponse,
   getEndpointAndRenderResponse
 }


### PR DESCRIPTION
PR for the following issue: https://github.com/mojaloop/project/issues/2608
- re-factoreed src/util/headers/transformer.js config options to include a protocolVersions parameter to configure there via injection at the application layer, instead of relying on the library looking for 'RESOURCE_VERSIONS' ENV variable. This is however still supported for backward compatibility going forward, but should be deprecated in future versions
- enhanced unit tests to validate both the legacy and new paths in configuration via protocolVersions and ENV variable
- updated dependencies
- fixed audit-resolve issues
- fixed lint issue