### PR TITLE
feat(mojaloop/#2704): core-services support for non-breaking backward api compatibility

### DIFF
--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -93,6 +93,16 @@
       "decision": "ignore",
       "madeAt": 1644227622831,
       "expiresAt": 1646819457744
+    },
+    "1007050|widdershins>urijs": {
+      "decision": "ignore",
+      "madeAt": 1646234133511,
+      "expiresAt": 1648826119845
+    },
+    "1007017|widdershins>swagger2openapi>oas-validator>ajv": {
+      "decision": "ignore",
+      "madeAt": 1646234136454,
+      "expiresAt": 1648826119845
     }
   },
   "rules": {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -436,9 +436,9 @@
       "integrity": "sha512-GoXw0U2Qaa33m3eUcxuHnHpNvHjNlLo0gtV091XBpaRINaB4X6FGCG5XKxSFNFiPpugUDqNruHzaqpTdDm4AOg=="
     },
     "@gar/promisify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
     },
     "@grpc/proto-loader": {
@@ -1199,9 +1199,9 @@
       }
     },
     "@npmcli/fs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.0.tgz",
-      "integrity": "sha512-VhP1qZLXcrXRIaPoqb4YA55JQxLNF3jNR4T55IdOJa3+IFJKNYHtPvtXx8slmeMavj37vCzCfrqQM1vWLsYKLA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
       "dev": true,
       "requires": {
         "@gar/promisify": "^1.0.1",
@@ -1220,21 +1220,28 @@
       }
     },
     "@npmcli/git": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.1.0.tgz",
-      "integrity": "sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-3.0.0.tgz",
+      "integrity": "sha512-xfSBJ+KBMZWWqRHFbEgIaXG/LtELHrQZMJ72Gkb3yWdHysu/7+VGOs8ME0c3td7QNQX57Ggo3kYL6ylcd70/kA==",
       "dev": true,
       "requires": {
         "@npmcli/promise-spawn": "^1.3.2",
-        "lru-cache": "^6.0.0",
+        "lru-cache": "^7.3.1",
         "mkdirp": "^1.0.4",
-        "npm-pick-manifest": "^6.1.1",
+        "npm-pick-manifest": "^7.0.0",
+        "proc-log": "^2.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
         "which": "^2.0.2"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.4.0.tgz",
+          "integrity": "sha512-YOfuyWa/Ee+PXbDm40j9WXyJrzQUynVbgn4Km643UYcWNcrSfRkKL0WaiUcxcIbkXcVTgNpDqSnPXntWXT75cw==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -1242,6 +1249,17 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            }
           }
         },
         "which": {
@@ -1291,15 +1309,15 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-2.0.0.tgz",
-      "integrity": "sha512-fSan/Pu11xS/TdaTpTB0MRn9guwGU8dye+x56mEVgBEd/QsybBbYcAL0phPXi8SGWFEChkQd6M9qL4y6VOpFig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-3.0.0.tgz",
+      "integrity": "sha512-jIdmUepw+kVP2WEE/+XrBIvrSF5miDutdGBrQ8May6uHVAvpAb0m3NRHcJ0lKWbQ1BxsRFsmTrjkdY99qTTVIw==",
       "dev": true,
       "requires": {
-        "@npmcli/node-gyp": "^1.0.2",
+        "@npmcli/node-gyp": "^1.0.3",
         "@npmcli/promise-spawn": "^1.3.2",
-        "node-gyp": "^8.2.0",
-        "read-package-json-fast": "^2.0.1"
+        "node-gyp": "^8.4.1",
+        "read-package-json-fast": "^2.0.3"
       }
     },
     "@protobufjs/aspromise": {
@@ -1537,9 +1555,9 @@
       }
     },
     "agentkeepalive": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
-      "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -2076,11 +2094,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
       "requires": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.14.8"
       }
     },
     "balanced-match": {
@@ -4642,9 +4660,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -7210,9 +7228,9 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-          "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz",
+          "integrity": "sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==",
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -7220,29 +7238,29 @@
           }
         },
         "gauge": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.0.tgz",
-          "integrity": "sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.2.tgz",
+          "integrity": "sha512-aSPRm2CvA9R8QyU5eXMFPd+cYkyxLsXHd2l5/FOH2V/eml//M04G6KZOmTap07O1PvEwNcl2NndyLfK8g3QrKA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.1",
             "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.2",
-            "console-control-strings": "^1.0.0",
+            "color-support": "^1.1.3",
+            "console-control-strings": "^1.1.0",
             "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.0",
+            "signal-exit": "^3.0.7",
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.2"
+            "wide-align": "^1.1.5"
           }
         },
         "npmlog": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.0.tgz",
-          "integrity": "sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.1.tgz",
+          "integrity": "sha512-BTHDvY6nrRHuRfyjt1MAufLxYdVXZfd099H4+i1f0lPywNQyI4foeNXJRObB/uy+TYqUW0vAD9gbdSOXPst7Eg==",
           "dev": true,
           "requires": {
-            "are-we-there-yet": "^2.0.0",
+            "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
             "gauge": "^4.0.0",
             "set-blocking": "^2.0.0"
@@ -7256,6 +7274,12 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "signal-exit": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.3",
@@ -7284,6 +7308,15 @@
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+          "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         }
       }
@@ -7395,15 +7428,15 @@
       }
     },
     "npm-check-updates": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-12.2.1.tgz",
-      "integrity": "sha512-fqfH2USwTLgho8HaC79i5Bl+RH3zV15AbdtJQTCaOAp9L3D2W8k+jsfuwee2vSTUrt6IUTXPbzwUIYo4/TQdYA==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-12.5.0.tgz",
+      "integrity": "sha512-nrryXO9IZdJsAIXo8LdtllrsGiTDE4IMAod7fl1jd5C38tOdZZG/crNNii4IkctxltQRmK/ziZwsMDTlhszZXg==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
         "cint": "^8.2.1",
         "cli-table": "^0.3.11",
-        "commander": "^8.3.0",
+        "commander": "^9.0.0",
         "fast-memoize": "^2.5.2",
         "find-up": "5.0.0",
         "fp-and-or": "^0.1.3",
@@ -7414,9 +7447,9 @@
         "jsonlines": "^0.1.1",
         "libnpmconfig": "^1.2.1",
         "lodash": "^4.17.21",
-        "minimatch": "^3.0.4",
+        "minimatch": "^5.0.0",
         "p-map": "^4.0.0",
-        "pacote": "^12.0.2",
+        "pacote": "^13.0.2",
         "parse-github-url": "^1.0.2",
         "progress": "^2.0.3",
         "prompts": "^2.4.2",
@@ -7427,7 +7460,8 @@
         "semver-utils": "^1.1.4",
         "source-map-support": "^0.5.21",
         "spawn-please": "^1.0.0",
-        "update-notifier": "^5.1.0"
+        "update-notifier": "^5.1.0",
+        "yaml": "^1.10.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7437,6 +7471,15 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
           }
         },
         "chalk": {
@@ -7465,9 +7508,9 @@
           "dev": true
         },
         "commander": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+          "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
           "dev": true
         },
         "find-up": {
@@ -7502,6 +7545,15 @@
           "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
           }
         },
         "p-limit": {
@@ -7569,16 +7621,25 @@
       "dev": true
     },
     "npm-package-arg": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
-      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-9.0.0.tgz",
+      "integrity": "sha512-yhzXxeor+Zfhe5MGwPdDumz6HtNlj2pMekWB95IX3CC6uDNgde0oPKHDCLDPoJqQfd0HqAWt+y4Hs5m7CK1+9Q==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^4.0.1",
-        "semver": "^7.3.4",
+        "hosted-git-info": "^4.1.0",
+        "semver": "^7.3.5",
         "validate-npm-package-name": "^3.0.0"
       },
       "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7603,15 +7664,15 @@
       }
     },
     "npm-pick-manifest": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-6.1.1.tgz",
-      "integrity": "sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-7.0.0.tgz",
+      "integrity": "sha512-njM1AcdioFaKd0JSGtLO09YA1WRwctjGQJbnHGmKS+u+uwP8oFvtZtOQWPYdxrnY5eJud3wn8OpH4sEIx6+GEQ==",
       "dev": true,
       "requires": {
         "npm-install-checks": "^4.0.0",
         "npm-normalize-package-bin": "^1.0.1",
-        "npm-package-arg": "^8.1.2",
-        "semver": "^7.3.4"
+        "npm-package-arg": "^9.0.0",
+        "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
@@ -7626,17 +7687,18 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-12.0.1.tgz",
-      "integrity": "sha512-ricy4ezH3Uv0d4am6RSwHjCYTWJI74NJjurIigWMAG7Vs3PFyd0TUlkrez5L0AgaPzDLRsEzqb5cOZ/Ue01bmA==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-13.0.0.tgz",
+      "integrity": "sha512-MmiMuV9DU5gRuAU0jia952Qq+E4h7ZoUaeltCXivhClcqfOVKqNLZEQsRUOb6a8WQY+um8x97JcUuaWFoPoBBw==",
       "dev": true,
       "requires": {
-        "make-fetch-happen": "^10.0.0",
-        "minipass": "^3.1.3",
-        "minipass-fetch": "^1.3.0",
+        "make-fetch-happen": "^10.0.2",
+        "minipass": "^3.1.6",
+        "minipass-fetch": "^1.4.1",
         "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.0.0",
-        "npm-package-arg": "^8.0.0"
+        "minizlib": "^2.1.2",
+        "npm-package-arg": "^9.0.0",
+        "proc-log": "^2.0.0"
       },
       "dependencies": {
         "@tootallnate/once": {
@@ -7665,28 +7727,43 @@
             "debug": "4"
           }
         },
+        "lru-cache": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.4.0.tgz",
+          "integrity": "sha512-YOfuyWa/Ee+PXbDm40j9WXyJrzQUynVbgn4Km643UYcWNcrSfRkKL0WaiUcxcIbkXcVTgNpDqSnPXntWXT75cw==",
+          "dev": true
+        },
         "make-fetch-happen": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.0.0.tgz",
-          "integrity": "sha512-CREcDkbKZZ64g5MN1FT+u58mDHX9FQFFtFyio5HonX44BdQdytqPZBXUz+6ibi2w/6ncji59f2phyXGSMGpgzA==",
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.0.3.tgz",
+          "integrity": "sha512-CzarPHynPpHjhF5in/YapnO44rSZeYX5VCMfdXa99+gLwpbfFLh20CWa6dP/taV9Net9PWJwXNKtp/4ZTCQnag==",
           "dev": true,
           "requires": {
-            "agentkeepalive": "^4.1.3",
-            "cacache": "^15.2.0",
+            "agentkeepalive": "^4.2.0",
+            "cacache": "^15.3.0",
             "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.3",
+            "lru-cache": "^7.3.1",
+            "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^1.3.2",
+            "minipass-fetch": "^1.4.1",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.3",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^6.0.0",
-            "ssri": "^8.0.0"
+            "socks-proxy-agent": "^6.1.1",
+            "ssri": "^8.0.1"
+          }
+        },
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
           }
         },
         "ms": {
@@ -8636,9 +8713,9 @@
       }
     },
     "openapi-backend": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.2.0.tgz",
-      "integrity": "sha512-ykzFWC6pOPdw55/Qx7oxncymXh4Vuv+M5QCgaoIo38lAQ+hhzZXKl9AtSQfa6di9g5rKFs2yrGeAzUV7uLv6RQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-5.2.1.tgz",
+      "integrity": "sha512-JTRk+ytxvSZ+XZRLpfLyNzQnVWEwMZv7Bl9GVHwwaTadcVjuhK/WLg5xpuAvZwtV1LGLDujCc6w9QjEp0BWVHw==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",
         "ajv": "^8.6.2",
@@ -8805,30 +8882,57 @@
       }
     },
     "pacote": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-12.0.3.tgz",
-      "integrity": "sha512-CdYEl03JDrRO3x18uHjBYA9TyoW8gy+ThVcypcDkxPtKlw76e4ejhYB6i9lJ+/cebbjpqPW/CijjqxwDTts8Ow==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-13.0.3.tgz",
+      "integrity": "sha512-8thQ06YoO01O1k5rvSpHS/XPJZucw2DPiiT1jI+ys8QaTN6ifAyxfyoABHBa8nIt/4wPdzly4GEPqshctHFoYA==",
       "dev": true,
       "requires": {
-        "@npmcli/git": "^2.1.0",
-        "@npmcli/installed-package-contents": "^1.0.6",
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
         "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^2.0.0",
-        "cacache": "^15.0.5",
+        "@npmcli/run-script": "^3.0.0",
+        "cacache": "^15.3.0",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
         "infer-owner": "^1.0.4",
-        "minipass": "^3.1.3",
-        "mkdirp": "^1.0.3",
-        "npm-package-arg": "^8.0.1",
+        "minipass": "^3.1.6",
+        "mkdirp": "^1.0.4",
+        "npm-package-arg": "^9.0.0",
         "npm-packlist": "^3.0.0",
-        "npm-pick-manifest": "^6.0.0",
-        "npm-registry-fetch": "^12.0.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-registry-fetch": "^13.0.0",
+        "proc-log": "^2.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json-fast": "^2.0.1",
+        "read-package-json": "^4.1.1",
+        "read-package-json-fast": "^2.0.3",
         "rimraf": "^3.0.2",
         "ssri": "^8.0.1",
-        "tar": "^6.1.0"
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "tar": {
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "parent-module": {
@@ -9198,6 +9302,12 @@
         "plur": "^1.0.0"
       }
     },
+    "proc-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.0.tgz",
+      "integrity": "sha512-I/35MfCX2H8jBUhKN8JB8nmqvQo/nKdrBodBY7L3RhDSPPyvOHwLYNmPuhwuJq7a7C3vgFKWGQM+ecPStcvOHA==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -9381,30 +9491,35 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "requires": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
       "dependencies": {
         "bytes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-          "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         },
         "http-errors": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "2.0.0",
             "inherits": "2.0.4",
             "setprototypeof": "1.2.0",
-            "statuses": ">= 1.5.0 < 2",
+            "statuses": "2.0.1",
             "toidentifier": "1.0.1"
           }
         },
@@ -9412,6 +9527,11 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
           "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         },
         "toidentifier": {
           "version": "1.0.1",
@@ -9494,6 +9614,50 @@
       "dev": true,
       "requires": {
         "mute-stream": "~0.0.4"
+      }
+    },
+    "read-package-json": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.1.tgz",
+      "integrity": "sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^3.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      },
+      "dependencies": {
+        "is-core-module": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "read-package-json-fast": {
@@ -11569,9 +11733,9 @@
       }
     },
     "tape": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.5.0.tgz",
-      "integrity": "sha512-hmsc9J+07tM+evk2Rkv7pkbj70Uoy9k0w1yhnN8Sza8kmjhtUTVNltsjywQjC+4grB+EBMKXiJPTkftX8IrbSA==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-5.5.2.tgz",
+      "integrity": "sha512-N9Ss672dFE3QlppiXGh2ieux8Ophau/HSAQguW5cXQworKxV0QvnZCYI35W1OYySTJk0OC9OPuS+0xNO6lhiTQ==",
       "dev": true,
       "requires": {
         "array.prototype.every": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@hapi/catbox": "11.1.1",
     "@hapi/catbox-memory": "5.0.1",
-    "axios": "0.25.0",
+    "axios": "0.26.0",
     "clone": "2.1.2",
     "dotenv": "16.0.0",
     "env-var": "7.1.1",
@@ -56,8 +56,8 @@
     "immutable": "4.0.0",
     "lodash": "4.17.21",
     "mustache": "4.2.0",
-    "openapi-backend": "5.2.0",
-    "raw-body": "2.4.2",
+    "openapi-backend": "5.2.1",
+    "raw-body": "2.5.1",
     "rc": "1.2.8",
     "shins": "2.6.0",
     "uuid4": "2.0.2",
@@ -77,7 +77,7 @@
     "base64url": "3.0.1",
     "chance": "1.1.8",
     "npm-audit-resolver": "2.3.1",
-    "npm-check-updates": "12.2.1",
+    "npm-check-updates": "12.5.0",
     "nyc": "15.1.0",
     "pre-commit": "1.2.2",
     "proxyquire": "2.1.3",
@@ -87,7 +87,7 @@
     "standard-version": "9.3.2",
     "tap-spec": "^5.0.0",
     "tap-xunit": "2.4.1",
-    "tape": "5.5.0",
+    "tape": "5.5.2",
     "tapes": "4.1.0"
   },
   "peerDependencies": {

--- a/src/util/hapi/plugins/headerValidation.js
+++ b/src/util/hapi/plugins/headerValidation.js
@@ -97,7 +97,10 @@ const plugin = {
           errorMessages.INVALID_CONTENT_TYPE_HEADER
         )
       }
-      if (!supportedProtocolContentVersions.includes(contentType.version)) {
+      // if (!supportedProtocolContentVersions.includes(contentType.version)) {
+      if (!supportedProtocolContentVersions.some(supportedVer => {
+        return contentType.version === supportedVer
+      })) {
         const supportedVersionExtensionListMap = convertSupportedVersionToExtensionList(supportedProtocolContentVersions)
         throw createFSPIOPError(
           Enums.FSPIOPErrorCodes.UNACCEPTABLE_VERSION,
@@ -107,7 +110,6 @@ const plugin = {
           supportedVersionExtensionListMap
         )
       }
-
       return h.continue
     })
   }

--- a/src/util/hapi/plugins/headerValidation.js
+++ b/src/util/hapi/plugins/headerValidation.js
@@ -98,9 +98,7 @@ const plugin = {
         )
       }
       // if (!supportedProtocolContentVersions.includes(contentType.version)) {
-      if (!supportedProtocolContentVersions.some(supportedVer => {
-        return contentType.version === supportedVer
-      })) {
+      if (!supportedProtocolContentVersions.some(supportedVer => contentType.version === supportedVer)) {
         const supportedVersionExtensionListMap = convertSupportedVersionToExtensionList(supportedProtocolContentVersions)
         throw createFSPIOPError(
           Enums.FSPIOPErrorCodes.UNACCEPTABLE_VERSION,


### PR DESCRIPTION
feat(mojaloop/#2704): core-services support for non-breaking backward api compatibility - https://github.com/mojaloop/project/issues/2704
- updated FSPIOPHeaderValidation options based on https://github.com/mojaloop/project/issues/2660 to accept a validationList for the content-type
- updated dependencies
- fixed audit issues

BREAKING CHANGE:
- headerValidation.FSPIOPHeaderValidation now expects the`supportedProtocolContentVersions` options argument to be a list, the same as `supportedProtocolAcceptVersions`