### PR TITLE
fix: add null check before passing payload to getRawBody

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "audit-ci": "^6.6.1",
         "base64url": "3.0.1",
         "chance": "1.1.11",
-        "npm-check-updates": "16.11.1",
+        "npm-check-updates": "16.11.2",
         "nyc": "15.1.0",
         "pre-commit": "1.2.2",
         "proxyquire": "2.1.3",
@@ -9759,9 +9759,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.11.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.11.1.tgz",
-      "integrity": "sha512-FgfhQc/LpY1u2BZpg+Y/FVoa8XxTjTpnAuSGdHM6CRqOO9pSPFrQ618HS9zf71ox7hPUQqpPvTaIuCpa4px38Q==",
+      "version": "16.11.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.11.2.tgz",
+      "integrity": "sha512-WliaMCkuXraU+yqubyTWNaQZCAxiSedBX1H7OoJ+7gulhTk+YF7zt9q30R+u/XYdLrqV6QvcuIqIvL8Q5NcwDA==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",
@@ -23334,9 +23334,9 @@
       }
     },
     "npm-check-updates": {
-      "version": "16.11.1",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.11.1.tgz",
-      "integrity": "sha512-FgfhQc/LpY1u2BZpg+Y/FVoa8XxTjTpnAuSGdHM6CRqOO9pSPFrQ618HS9zf71ox7hPUQqpPvTaIuCpa4px38Q==",
+      "version": "16.11.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.11.2.tgz",
+      "integrity": "sha512-WliaMCkuXraU+yqubyTWNaQZCAxiSedBX1H7OoJ+7gulhTk+YF7zt9q30R+u/XYdLrqV6QvcuIqIvL8Q5NcwDA==",
       "dev": true,
       "requires": {
         "chalk": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "17.5.2",
+  "version": "17.5.3-snapshot.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/central-services-shared",
-      "version": "17.5.2",
+      "version": "17.5.3-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/catbox": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "audit-ci": "^6.6.1",
     "base64url": "3.0.1",
     "chance": "1.1.11",
-    "npm-check-updates": "16.11.1",
+    "npm-check-updates": "16.11.2",
     "nyc": "15.1.0",
     "pre-commit": "1.2.2",
     "proxyquire": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "17.5.2",
+  "version": "17.5.3-snapshot.0",
   "description": "Shared code for mojaloop central services",
   "license": "Apache-2.0",
   "author": "ModusBox",

--- a/src/util/hapi/plugins/rawPayloadToDataUri.js
+++ b/src/util/hapi/plugins/rawPayloadToDataUri.js
@@ -75,15 +75,18 @@ module.exports.plugin = {
       server.ext([{
         type: 'onPostAuth',
         method: async (request, h) => {
-          return getRawBody(request.payload)
-            .then(rawBuffer => {
-              if (Buffer.byteLength(rawBuffer) !== 0) {
-                request = requestRawPayloadTransform(request, rawBuffer)
-              }
-              return h.continue
-            }).catch(() => {
-              return h.continue
-            })
+          if (request.payload) {
+            return getRawBody(request.payload)
+              .then(rawBuffer => {
+                if (Buffer.byteLength(rawBuffer) !== 0) {
+                  request = requestRawPayloadTransform(request, rawBuffer)
+                }
+                return h.continue
+              }).catch(() => {
+                return h.continue
+              })
+          }
+          return h.continue
         }
       }])
     }


### PR DESCRIPTION
In `raw-body` they added a validation check for the arguments of `getRawData`

https://github.com/stream-utils/raw-body/compare/2.5.1...2.5.2#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R72

In get requests and the such payload is `undefined` so just doing an truthy check.