### PR TITLE
refactor(mojaloop/#3498)!: refactor message keying logic in proceed function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "17.6.3",
+  "version": "17.6.4-snapshot.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/central-services-shared",
-      "version": "17.6.3",
+      "version": "17.6.4-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/catbox": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "17.6.3",
+  "version": "17.6.4-snapshot.0",
   "description": "Shared code for mojaloop central services",
   "license": "Apache-2.0",
   "author": "ModusBox",

--- a/src/util/kafka/index.js
+++ b/src/util/kafka/index.js
@@ -285,7 +285,7 @@ const commitMessageSync = async (kafkaConsumer, kafkaTopic, message) => {
 
 const proceed = async (defaultKafkaConfig, params, opts) => {
   const { message, kafkaTopic, consumer, decodedPayload, span, producer } = params
-  const { consumerCommit, fspiopError, eventDetail, fromSwitch, toDestination } = opts
+  const { consumerCommit, fspiopError, eventDetail, fromSwitch, toDestination, messageKey } = opts
   let metadataState
 
   if (consumerCommit) {
@@ -305,15 +305,12 @@ const proceed = async (defaultKafkaConfig, params, opts) => {
     message.value.from = Enum.Http.Headers.FSPIOP.SWITCH.value
     if (message.value.content.headers) message.value.content.headers[Enum.Http.Headers.FSPIOP.DESTINATION] = message.value.to
   }
-  let key
   if (typeof toDestination === 'string') {
     message.value.to = toDestination
     if (message.value.content.headers) message.value.content.headers[Enum.Http.Headers.FSPIOP.DESTINATION] = toDestination
-  } else if (toDestination === true) {
-    key = message.value.content.headers && message.value.content.headers[Enum.Http.Headers.FSPIOP.DESTINATION]
   }
   if (eventDetail && producer) {
-    await produceGeneralMessage(defaultKafkaConfig, producer, eventDetail.functionality, eventDetail.action, message.value, metadataState, key, span)
+    await produceGeneralMessage(defaultKafkaConfig, producer, eventDetail.functionality, eventDetail.action, message.value, metadataState, messageKey?.toString(), span)
   }
   return true
 }

--- a/src/util/kafka/index.js
+++ b/src/util/kafka/index.js
@@ -310,7 +310,7 @@ const proceed = async (defaultKafkaConfig, params, opts) => {
     if (message.value.content.headers) message.value.content.headers[Enum.Http.Headers.FSPIOP.DESTINATION] = toDestination
   }
   if (eventDetail && producer) {
-    await produceGeneralMessage(defaultKafkaConfig, producer, eventDetail.functionality, eventDetail.action, message.value, metadataState, messageKey?.toString(), span)
+    await produceGeneralMessage(defaultKafkaConfig, producer, eventDetail.functionality, eventDetail.action, message.value, metadataState, messageKey, span)
   }
   return true
 }

--- a/test/unit/util/kafka/index.test.js
+++ b/test/unit/util/kafka/index.test.js
@@ -516,7 +516,7 @@ Test('Utility Test', utilityTest => {
     })
 
     proceedTest.test('produce message when messageKey is specified', async test => {
-      const opts = { consumerCommit: true, eventDetail, messageKey: 101 }
+      const opts = { consumerCommit: true, eventDetail, messageKey: '101' }
       try {
         const result = await UtilityProxy.proceed(Config.KAFKA_CONFIG, params, opts)
         test.ok(commitMessageSyncStub.calledOnce, 'commitMessageSyncStub not called')


### PR DESCRIPTION
refactor(mojaloop/#3498): refactor message keying logic in proceed function - https://github.com/mojaloop/project/issues/3498

- Rework keying logic in `proceed` to be simplier
- Add messageKey test and rework tests

I didn't like how the tests did not reset test data on each test when `proceed` mutates the message passed in, so I reworked it and changed some of the assertions. Adding tests would break and assertions were working off of data that had been altered in previous tests. I believe it was passing just on happenstance.