### PR TITLE
Fix excessive span logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "18.3.4",
+  "version": "18.3.5-snapshot.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/central-services-shared",
-      "version": "18.3.4",
+      "version": "18.3.5-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/catbox": "12.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "yaml": "2.4.1"
       },
       "devDependencies": {
-        "@hapi/hapi": "21.3.8",
+        "@hapi/hapi": "21.3.9",
         "@hapi/joi": "17.1.1",
         "audit-ci": "^6.6.1",
         "base64url": "3.0.1",
@@ -899,9 +899,9 @@
       "dev": true
     },
     "node_modules/@hapi/hapi": {
-      "version": "21.3.8",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.8.tgz",
-      "integrity": "sha512-2YGNQZTnWKAWiexoLxvsSFFpJvFBJKhtRzARNxR6G1dHbDfL1WPQBXF00rmMRJLdo+oi7d+Ntgdno6V+z+js7w==",
+      "version": "21.3.9",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.9.tgz",
+      "integrity": "sha512-AT5m+Rb8iSOFG3zWaiEuTJazf4HDYl5UpRpyxMJ3yR+g8tOEmqDv6FmXrLHShdvDOStAAepHGnr1G7egkFSRdw==",
       "dev": true,
       "dependencies": {
         "@hapi/accept": "^6.0.1",
@@ -14860,9 +14860,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "yaml": "2.4.1"
   },
   "devDependencies": {
-    "@hapi/hapi": "21.3.8",
+    "@hapi/hapi": "21.3.9",
     "@hapi/joi": "17.1.1",
     "audit-ci": "^6.6.1",
     "base64url": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "18.3.4",
+  "version": "18.3.5-snapshot.0",
   "description": "Shared code for mojaloop central services",
   "license": "Apache-2.0",
   "author": "ModusBox",

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -41,6 +41,7 @@ delete request.defaults.headers.common.Accept
 
 // Enable keepalive for http
 request.defaults.httpAgent = new http.Agent({ keepAlive: true })
+axios.defaults.httpAgent.toJSON = () => ({})
 
 /**
  * @function sendRequest

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -41,7 +41,7 @@ delete request.defaults.headers.common.Accept
 
 // Enable keepalive for http
 request.defaults.httpAgent = new http.Agent({ keepAlive: true })
-axios.defaults.httpAgent.toJSON = () => ({})
+request.defaults.httpAgent.toJSON = () => ({})
 
 /**
  * @function sendRequest

--- a/test/unit/util/request.test.js
+++ b/test/unit/util/request.test.js
@@ -182,6 +182,7 @@ Test('ParticipantEndpoint Model Test', modelTest => {
         test.end()
       } catch (e) {
         test.ok(e instanceof Error)
+        test.ok(request.defaults.httpAgent.toJSON())
         test.end()
       }
     })


### PR DESCRIPTION
Errors thrown by `axios` are serializing the full agent object, which contain a lot of nested objects, including data for in-progress requests and their buffers. This is being sent to the sidecar, where sending to Kafka fails with error `Broker: Message size too large`. This fix avoids serializing the agent properties in the thrown errors.