### PR TITLE
feat: id generators for uuid versions 4 and 7

### DIFF
--- a/src/util/id.js
+++ b/src/util/id.js
@@ -27,7 +27,7 @@ const crypto = require('crypto')
 
 const generators = {
   // generate UUID compliant with https://datatracker.ietf.org/doc/html/rfc9562
-  uuid: ({ version }) => ({
+  uuid: ({ version = 7 }) => ({
     4: crypto.randomUUID,
     7: () => {
       const timestamp = Date.now().toString(16).padStart(12, 0)
@@ -37,4 +37,4 @@ const generators = {
   })[version]
 }
 
-module.exports = ({ type, ...config }) => generators[type](config)
+module.exports = ({ type = 'uuid', ...config } = {}) => generators[type](config)

--- a/src/util/id.js
+++ b/src/util/id.js
@@ -1,0 +1,40 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+
+ * Infitx
+ - Kalin Krustev <kalin.krustev@infitx.com>
+
+ --------------
+ ******/
+
+const crypto = require('crypto')
+
+const generators = {
+  // generate UUID compliant with https://datatracker.ietf.org/doc/html/rfc9562
+  uuid: ({ version }) => ({
+    4: crypto.randomUUID,
+    7: () => {
+      const timestamp = Date.now().toString(16).padStart(12, 0)
+      const random = crypto.randomUUID()
+      return `${timestamp.substring(0, 8)}-${timestamp.substring(8, 12)}-7${random.substring(15, 36)}`
+    }
+  })[version]
+}
+
+module.exports = ({ type, ...config }) => generators[type](config)

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -45,6 +45,7 @@ const Settlement = require('./settlement')
 const EventFramework = require('./eventFramework')
 const Schema = require('./schema')
 const OpenapiBackend = require('./openapiBackend')
+const id = require('./id')
 
 const omitNil = (object) => {
   return _.omitBy(object, _.isNil)
@@ -252,5 +253,6 @@ module.exports = {
   Settlement,
   Schema,
   OpenapiBackend,
+  id,
   resourceVersions: Helpers.resourceVersions
 }

--- a/test/unit/util/id.test.js
+++ b/test/unit/util/id.test.js
@@ -26,6 +26,7 @@
 const Test = require('tapes')(require('tape'))
 const Sinon = require('sinon')
 const idGenerator = require('../../../src/util/id')
+const uuidRegex = version => new RegExp(`[a-f0-9]{8}-[a-f0-9]{4}-${version}[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}`)
 
 Test('Id util', idTest => {
   let sandbox
@@ -43,12 +44,17 @@ Test('Id util', idTest => {
   idTest.test('Id should', generateSha256Test => {
     generateSha256Test.test('generate UUID v4', test => {
       const uuid4 = idGenerator({ type: 'uuid', version: 4 })
-      test.match(uuid4(), /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}/)
+      test.match(uuid4(), uuidRegex(4))
       test.end()
     })
     generateSha256Test.test('generate UUID v7', test => {
       const uuid7 = idGenerator({ type: 'uuid', version: 7 })
-      test.match(uuid7(), /[a-f0-9]{8}-[a-f0-9]{4}-7[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}/)
+      test.match(uuid7(), uuidRegex(7))
+      test.end()
+    })
+    generateSha256Test.test('generate UUID v7 by default', test => {
+      const uuid = idGenerator()
+      test.match(uuid(), uuidRegex(7))
       test.end()
     })
     generateSha256Test.end()

--- a/test/unit/util/id.test.js
+++ b/test/unit/util/id.test.js
@@ -1,0 +1,58 @@
+/*****
+ License
+ --------------
+ Copyright © 2017 Bill & Melinda Gates Foundation
+ The Mojaloop files are made available by the Bill & Melinda Gates Foundation under the Apache License, Version 2.0 (the "License") and you may not use these files except in compliance with the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, the Mojaloop files are distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ Contributors
+ --------------
+ This is the official list of the Mojaloop project contributors for this file.
+ Names of the original copyright holders (individuals or organizations)
+ should be listed with a '*' in the first column. People who have
+ contributed from an organization can be listed under the organization
+ that actually holds the copyright for their contributions (see the
+ Gates Foundation organization for an example). Those individuals should have
+ their names indented and be marked with a '-'. Email address can be added
+ optionally within square brackets <email>.
+ * Gates Foundation
+
+ * Infitx
+ - Kalin Krustev <kalin.krustev@infitx.com>
+ --------------
+ ******/
+'use strict'
+
+const Test = require('tapes')(require('tape'))
+const Sinon = require('sinon')
+const idGenerator = require('../../../src/util/id')
+
+Test('Id util', idTest => {
+  let sandbox
+
+  idTest.beforeEach(t => {
+    sandbox = Sinon.createSandbox()
+    t.end()
+  })
+
+  idTest.afterEach(t => {
+    sandbox.restore()
+    t.end()
+  })
+
+  idTest.test('Id should', generateSha256Test => {
+    generateSha256Test.test('generate UUID v4', test => {
+      const uuid4 = idGenerator({ type: 'uuid', version: 4 })
+      test.match(uuid4(), /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}/)
+      test.end()
+    })
+    generateSha256Test.test('generate UUID v7', test => {
+      const uuid7 = idGenerator({ type: 'uuid', version: 7 })
+      test.match(uuid7(), /[a-f0-9]{8}-[a-f0-9]{4}-7[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}/)
+      test.end()
+    })
+    generateSha256Test.end()
+  })
+
+  idTest.end()
+})


### PR DESCRIPTION
Example usage:
```js
const uuidv7 = require('@mojaloop/central-services-shared').Util.id({type: 'uuid', version: 7})
uuidv7() // generate a new id
```

But the idea is that id generation will be configurable via the object passed to the function