### PR TITLE
feat: log request error details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hapi/catbox": "12.1.1",
         "@hapi/catbox-memory": "5.0.1",
         "@mojaloop/inter-scheme-proxy-cache-lib": "2.3.0",
-        "axios": "1.7.7",
+        "axios": "1.7.8",
         "clone": "2.1.2",
         "dotenv": "16.4.5",
         "env-var": "7.5.0",
@@ -2047,9 +2047,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.8.tgz",
+      "integrity": "sha512-Uu0wb7KNqK2t5K+YQyVCLM76prD5sRFjKHbJYCP1J7JFGEQ6nN7HWn9+04LAeiJ3ji54lgS/gZCH1oxyrf1SPw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@hapi/catbox": "12.1.1",
     "@hapi/catbox-memory": "5.0.1",
     "@mojaloop/inter-scheme-proxy-cache-lib": "2.3.0",
-    "axios": "1.7.7",
+    "axios": "1.7.8",
     "clone": "2.1.2",
     "dotenv": "16.4.5",
     "env-var": "7.5.0",

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -139,7 +139,17 @@ const sendRequest = async ({
     histTimerEnd({ success: true, source, destination, method })
     return response
   } catch (error) {
-    logger.warn('error in request.sendRequest:', error)
+    logger.error('error in request.sendRequest:', {
+      code: error.code,
+      message: error.message,
+      stack: error.stack,
+      method,
+      url,
+      source,
+      destination,
+      status: error.response?.status,
+      data: error.response?.data
+    })
     const extensionArray = [
       { key: 'url', value: url },
       { key: 'sourceFsp', value: source },
@@ -150,7 +160,6 @@ const sendRequest = async ({
     ]
     const extensions = []
     if (error.response) {
-      logger.verbose('error.response.data:', error.response.data)
       extensionArray.push({ key: 'status', value: error.response?.status })
       extensionArray.push({ key: 'response', value: error.response?.data })
       extensions.push({ key: 'status', value: error.response?.status })


### PR DESCRIPTION
It is important to log error details, so that they are available to error-aggregator tools like loki to enable faster identifying of error reasons. The most common cases are 400 and 500 errors, which may often include important details in the body, but these details are not currently logged.