### PR TITLE
chore: standardize egress audit key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "18.14.0",
+  "version": "18.14.1-snapshot.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/central-services-shared",
-      "version": "18.14.0",
+      "version": "18.14.1-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/catbox": "12.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "18.14.1-snapshot.0",
+  "version": "18.14.1-snapshot.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/central-services-shared",
-      "version": "18.14.1-snapshot.0",
+      "version": "18.14.1-snapshot.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/catbox": "12.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "18.14.1-snapshot.0",
+  "version": "18.14.1-snapshot.1",
   "description": "Shared code for mojaloop central services",
   "license": "Apache-2.0",
   "author": "ModusBox",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-shared",
-  "version": "18.14.0",
+  "version": "18.14.1-snapshot.0",
   "description": "Shared code for mojaloop central services",
   "license": "Apache-2.0",
   "author": "ModusBox",

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -131,6 +131,13 @@ const sendRequest = async ({
     if (span) {
       requestOptions = span.injectContextToHttpRequest(requestOptions)
       const { data, ...rest } = requestOptions
+      if (typeof payload === 'string') {
+        try {
+          payload = JSON.parse(payload)
+        } catch (e) {
+          // do nothing
+        }
+      }
       span.audit({ ...rest, payload }, EventSdk.AuditEventAction.egress)
     }
     logger.debug('sendRequest::requestOptions:', { requestOptions })

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -130,7 +130,8 @@ const sendRequest = async ({
 
     if (span) {
       requestOptions = span.injectContextToHttpRequest(requestOptions)
-      span.audit(requestOptions, EventSdk.AuditEventAction.egress)
+      const { data, ...rest } = requestOptions
+      span.audit({ ...rest, payload }, EventSdk.AuditEventAction.egress)
     }
     logger.debug('sendRequest::requestOptions:', { requestOptions })
     const response = await request(requestOptions)


### PR DESCRIPTION
Found that with services bouncing between json strings better to just enforce payload being an object here for `sendRequest`