### PR TITLE
chore: fix dependency loop

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -5,5 +5,6 @@
   "moderate": true,
   "allowlist": [ // NOTE: Please add as much information as possible to any items added to the allowList
     // e.g. Currently no fixes available for the following
+    "GHSA-jr5f-v2jv-69x6" // temporarily add for fixing the dependency loop central-services-shared => sdk-standard-components => ml-schema-transformer-lib
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@hapi/hapi": "21.4.0",
         "@hapi/joi-date": "2.0.1",
         "@mojaloop/inter-scheme-proxy-cache-lib": "2.3.7",
-        "@mojaloop/sdk-standard-components": "19.9.0",
         "axios": "1.8.2",
         "clone": "2.1.2",
         "dotenv": "16.4.7",
@@ -36,13 +35,14 @@
         "yaml": "2.7.0"
       },
       "devDependencies": {
+        "@mojaloop/sdk-standard-components": "19.10.0",
         "@types/hapi__joi": "17.1.15",
         "audit-ci": "7.1.0",
         "base64url": "3.0.1",
         "chance": "1.1.12",
         "npm-check-updates": "17.1.15",
         "nyc": "17.1.0",
-        "portfinder": "1.0.33",
+        "portfinder": "1.0.34",
         "pre-commit": "1.2.2",
         "proxyquire": "2.1.3",
         "replace": "1.2.2",
@@ -1071,6 +1071,7 @@
       "version": "18.21.0",
       "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-18.21.0.tgz",
       "integrity": "sha512-k7vFBlIeYpli+8GQdGBMt7ykg4a18axo/As2G3wEemloA8kQZvK76rNWQy9i1URxc0hDT8W5xSHhXHIwwF2UPg==",
+      "dev": true,
       "dependencies": {
         "@hapi/catbox": "12.1.1",
         "@hapi/catbox-memory": "5.0.1",
@@ -1130,6 +1131,7 @@
       "version": "21.3.12",
       "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.12.tgz",
       "integrity": "sha512-GCUP12dkb3QMjpFl+wEFO73nqKRmsnD5um/QDOn6lj2GjGBrDXPcT194mNARO+PPNXZOR4KmvIpHt/lceUncfg==",
+      "dev": true,
       "dependencies": {
         "@hapi/accept": "^6.0.3",
         "@hapi/ammo": "^6.0.1",
@@ -1158,6 +1160,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.2.tgz",
       "integrity": "sha512-H1l4ugoFW/ZRkqeFrIo8p1rWN0PA4MDTfu4JmcoNDvnY975o29mqoZblqFTotxNHlEkMPpIiIBJTV+Mbi+aF0g==",
+      "dev": true,
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
@@ -1167,6 +1170,7 @@
       "version": "18.18.2",
       "resolved": "https://registry.npmjs.org/@mojaloop/central-services-shared/-/central-services-shared-18.18.2.tgz",
       "integrity": "sha512-hBXcuxwhdu4IBDd3wG5FYLJUOZE2bR31KPbPAd3j1gHCDBZMAPf0PEPh6GKNHor4v1pzlrPl5PcvctXDit6j5A==",
+      "dev": true,
       "dependencies": {
         "@hapi/catbox": "12.1.1",
         "@hapi/catbox-memory": "5.0.1",
@@ -1226,6 +1230,7 @@
       "version": "19.6.6",
       "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-19.6.6.tgz",
       "integrity": "sha512-6zRplfMu1DZfgxdoyu58RK8O4UVAV7Ghb62UNGlUkvGT5woo/ebt9ZJKSbR6YjzkFhPXfrVo1+NaYRfGSRdRig==",
+      "dev": true,
       "dependencies": {
         "@mojaloop/ml-schema-transformer-lib": "^2.5.3",
         "axios": "1.7.9",
@@ -1238,10 +1243,23 @@
         "jws": "4.0.0"
       }
     },
+    "node_modules/@mojaloop/central-services-shared/node_modules/@mojaloop/central-services-shared/node_modules/@mojaloop/sdk-standard-components/node_modules/axios": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@mojaloop/central-services-shared/node_modules/@mojaloop/central-services-shared/node_modules/axios": {
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
       "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1252,6 +1270,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@mojaloop/inter-scheme-proxy-cache-lib/-/inter-scheme-proxy-cache-lib-2.3.3.tgz",
       "integrity": "sha512-WViXF8++KZULO/Rf45VBWS7sOCx8pf82EauuERHFB5EcIq32QI+9SsvcDbe8dgecGW5PevXjaHuV+30FQ4YijQ==",
+      "dev": true,
       "dependencies": {
         "@mojaloop/central-services-logger": "11.5.5",
         "ajv": "8.17.1",
@@ -1267,6 +1286,7 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/@mojaloop/ml-schema-transformer-lib/-/ml-schema-transformer-lib-2.5.4.tgz",
       "integrity": "sha512-ENHrRiR52ZgG7VbKIHBcWnKE9R1NQntgUSD6xG6o961+PM3Cq/qTXirGhjiAjO8Q9IaxlU9LoyOBZHTZs5raYQ==",
+      "dev": true,
       "dependencies": {
         "@mojaloop/central-services-error-handling": "13.0.6",
         "@mojaloop/central-services-logger": "11.5.5",
@@ -1285,6 +1305,7 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/@mojaloop/central-services-error-handling/-/central-services-error-handling-13.0.6.tgz",
       "integrity": "sha512-tDOhUSr9MSVpqtBkn3oNc8TGJ/TGav8W/UmqW71WskF8musL5toEv0nZOAEn9nxKPb/Xj0b83EYeAOBiOD6ozA==",
+      "dev": true,
       "dependencies": {
         "fast-safe-stringify": "2.1.1",
         "lodash": "4.17.21"
@@ -1294,6 +1315,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
       "integrity": "sha512-QEGqY0HzGrue4r+4GWWe7lB7Xvjij4cyc2XeOTHYmwkO0BjgwzJW85mZJzR9q5HmK8zdFkN6C0CfedAaYiUv9w==",
+      "dev": true,
       "dependencies": {
         "bignumber.js": "^5.0.0",
         "extensible-error": "^1.0.2",
@@ -1305,6 +1327,7 @@
       "version": "19.7.1",
       "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-19.7.1.tgz",
       "integrity": "sha512-VnfhZANqpa+4iVybwPeafB7bfcQkiochO95X3oQ1YFuxblmFf9WyxMLtevG6PGv2OK9j/tI17QQqbuoL60/Gag==",
+      "dev": true,
       "dependencies": {
         "@mojaloop/ml-schema-transformer-lib": "2.5.4",
         "axios": "1.8.1",
@@ -1317,6 +1340,18 @@
         "jws": "4.0.0"
       }
     },
+    "node_modules/@mojaloop/central-services-shared/node_modules/@mojaloop/sdk-standard-components/node_modules/axios": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@mojaloop/central-services-shared/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.34.8",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
@@ -1324,6 +1359,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1333,6 +1369,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
       "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -1344,6 +1381,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.5.0.tgz",
       "integrity": "sha512-7CutT89g23FfSa8MDoIFs2GYYa0PaNiW/OrT+nRyjRXHDZd17HmIgy+reOQ/yhh72NznNjGuS8kbCAcA4Ro4mw==",
+      "dev": true,
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
         "cluster-key-slot": "^1.1.0",
@@ -1367,6 +1405,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -1374,7 +1413,8 @@
     "node_modules/@mojaloop/central-services-shared/node_modules/oer-utils": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
-      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA=="
+      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA==",
+      "dev": true
     },
     "node_modules/@mojaloop/event-sdk": {
       "version": "14.1.5",
@@ -1452,6 +1492,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@mojaloop/ml-schema-transformer-lib/-/ml-schema-transformer-lib-2.5.6.tgz",
       "integrity": "sha512-1VQn5CBmVKI89jeoW8pGJKM3J+PyQiw70eQIv5udSJsdBArFnpABxl72Ht5XupUaInHFLm2nm2C9UcVBxJl1KA==",
+      "dev": true,
       "dependencies": {
         "@mojaloop/central-services-error-handling": "13.0.7",
         "@mojaloop/central-services-logger": "11.5.5",
@@ -1470,6 +1511,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-2.2.0.tgz",
       "integrity": "sha512-QEGqY0HzGrue4r+4GWWe7lB7Xvjij4cyc2XeOTHYmwkO0BjgwzJW85mZJzR9q5HmK8zdFkN6C0CfedAaYiUv9w==",
+      "dev": true,
       "dependencies": {
         "bignumber.js": "^5.0.0",
         "extensible-error": "^1.0.2",
@@ -1481,6 +1523,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -1488,15 +1531,19 @@
     "node_modules/@mojaloop/ml-schema-transformer-lib/node_modules/oer-utils": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
-      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA=="
+      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA==",
+      "dev": true
     },
     "node_modules/@mojaloop/sdk-standard-components": {
-      "version": "19.9.0",
-      "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-19.9.0.tgz",
-      "integrity": "sha512-WhX64oUzIopzq4rdrVTcj2WPfaaTmPb7SZku2qI9Ii3gulcZOXT7wu83MS3C4pmdPgA5NjYPtg06YbKO1/zJpQ==",
+      "version": "19.10.0",
+      "resolved": "https://registry.npmjs.org/@mojaloop/sdk-standard-components/-/sdk-standard-components-19.10.0.tgz",
+      "integrity": "sha512-PrU4UlUK//qlbfFtjAHw8hhb/AI2rBUouyvoxVyvpbKdiySiuFqCZxBd+TkbQr8kGMTBBGgzMr+Tsyqlttzc7w==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
+        "@mojaloop/central-services-logger": "11.5.5",
         "@mojaloop/ml-schema-transformer-lib": "2.5.6",
-        "axios": "1.8.1",
+        "axios": "1.8.2",
         "axios-retry": "4.5.0",
         "base64url": "3.0.1",
         "fast-safe-stringify": "2.1.1",
@@ -1504,17 +1551,6 @@
         "ilp-packet-v1": "2.2.0",
         "jsonwebtoken": "9.0.2",
         "jws": "4.0.0"
-      }
-    },
-    "node_modules/@mojaloop/sdk-standard-components/node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1632,6 +1668,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1730,7 +1767,8 @@
     "node_modules/@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -2139,13 +2177,10 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -2214,6 +2249,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
       "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "dev": true,
       "dependencies": {
         "is-retry-allowed": "^2.2.0"
       },
@@ -2230,6 +2266,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2243,6 +2280,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
       "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -2405,7 +2443,8 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3747,6 +3786,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -4885,7 +4925,8 @@
     "node_modules/extensible-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extensible-error/-/extensible-error-1.0.2.tgz",
-      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g=="
+      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g==",
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5292,19 +5333,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -6137,6 +6165,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/ilp-packet/-/ilp-packet-3.1.3.tgz",
       "integrity": "sha512-FBsiPQbHPdLPI6jdA+sQO+4fFBuMc212yCdNXMqoGJdic2GFHF/E8P9bTorIVRZRVExhWDE5givqCMguupW8VA==",
+      "dev": true,
       "dependencies": {
         "extensible-error": "^1.0.2",
         "oer-utils": "^5.1.2"
@@ -6146,6 +6175,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ilp-packet-v1/-/ilp-packet-v1-2.2.0.tgz",
       "integrity": "sha512-bNsvjJ2/5Pl/qoVoSo4e/ZPoKv3xSm0VCO3fOPS+Yl5L4SZ6QRI972vclZKBwWDT19he2TgFZAmwe4RUzQ31jg==",
+      "dev": true,
       "dependencies": {
         "bignumber.js": "^5.0.0",
         "extensible-error": "^1.0.2",
@@ -6157,6 +6187,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -6164,7 +6195,8 @@
     "node_modules/ilp-packet-v1/node_modules/oer-utils": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-1.3.4.tgz",
-      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA=="
+      "integrity": "sha512-JTRqe1iQuB0weu1Mppu0YUApL6CU0CxtmB8pJIhTyTm4X7rmps6p18GVRzwHRfvSP7YUGakzgA+xPqZseF1FOA==",
+      "dev": true
     },
     "node_modules/immutable": {
       "version": "5.0.3",
@@ -6635,6 +6667,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6975,11 +7008,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jake/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
-    },
     "node_modules/jake/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7183,6 +7211,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dev": true,
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -7204,6 +7233,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dev": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -7214,6 +7244,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -7244,6 +7275,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dev": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -7254,6 +7286,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dev": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -7416,7 +7449,8 @@
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
@@ -7426,12 +7460,14 @@
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -7442,17 +7478,20 @@
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7462,7 +7501,8 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -7554,6 +7594,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-any-cjs/-/map-any-cjs-1.0.1.tgz",
       "integrity": "sha512-sTO3ceFtm5rT9+sUtrBHiQgd24SlMrIBGZkoLBFSQRbT1GzORdiO0SDaQqDlUSvBsGxEywHCA7CyX4tWPolSEw==",
+      "dev": true,
       "engines": {
         "node": ">= 18"
       }
@@ -7579,6 +7620,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/map-transform-cjs/-/map-transform-cjs-0.2.0.tgz",
       "integrity": "sha512-Dn2biqrp6w0OZq6sXh3shMBgpPcN13UL9kpwoLELCoWMXWcwkzjFLPagoL6sq1bZZpEREvW3YEooZtpPlYDWpw==",
+      "dev": true,
       "dependencies": {
         "deepmerge": "^4.3.1",
         "map-any-cjs": "^1.0.1"
@@ -8539,6 +8581,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-5.1.2.tgz",
       "integrity": "sha512-VhkvT3bthHrbnwBOG9vGpDFB8XHrIitpZY2nC+3scZI2Tf17g8YmeDK6wsA7HpdjGXMsbf14fRgltBXwhzrWOw==",
+      "dev": true,
       "dependencies": {
         "@types/long": "4.0.1",
         "long": "^4.0.0"
@@ -8547,7 +8590,8 @@
     "node_modules/oer-utils/node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -9062,26 +9106,18 @@
       }
     },
     "node_modules/portfinder": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.33.tgz",
-      "integrity": "sha512-+2jndHT63cL5MdQOwDm9OT2dIe11zVpjV+0GGRXdtO1wpPxv260NfVqoEXtYAi/shanmm3W4+yLduIe55ektTw==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.34.tgz",
+      "integrity": "sha512-aTyliYB9lpGRx0iUzgbLpCz3xiCEBsPOiukSp1X8fOnHalHCKNxxpv2cSc00Cc49mpWUtlyRVFHRSaRJF8ew3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "async": "^2.6.4",
-        "debug": "^3.2.7",
+        "async": "^3.2.6",
+        "debug": "^4.3.6",
         "mkdirp": "^0.5.6"
       },
       "engines": {
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/portfinder/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.1"
+        "node": ">= 6.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -10062,6 +10098,7 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12274,11 +12311,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/winston/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/winston/node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@hapi/hapi": "21.4.0",
     "@hapi/joi-date": "2.0.1",
     "@mojaloop/inter-scheme-proxy-cache-lib": "2.3.7",
-    "@mojaloop/sdk-standard-components": "19.9.0",
     "axios": "1.8.2",
     "clone": "2.1.2",
     "dotenv": "16.4.7",
@@ -86,13 +85,14 @@
     "yaml": "2.7.0"
   },
   "devDependencies": {
+    "@mojaloop/sdk-standard-components": "19.10.0",
     "@types/hapi__joi": "17.1.15",
     "audit-ci": "7.1.0",
     "base64url": "3.0.1",
     "chance": "1.1.12",
     "npm-check-updates": "17.1.15",
     "nyc": "17.1.0",
-    "portfinder": "1.0.33",
+    "portfinder": "1.0.34",
     "pre-commit": "1.2.2",
     "proxyquire": "2.1.3",
     "replace": "1.2.2",


### PR DESCRIPTION
There will be 4 related PRs aiming to fix a dependency loop between central-services-shared => sdk-standard-components => ml-schema-transformer-lib , which results in npm audit to fail with this advisory https://github.com/advisories/GHSA-jr5f-v2jv-69x6